### PR TITLE
deframer: reproduction test for out-of-bounds panic for quic append_hs

### DIFF
--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -4455,6 +4455,39 @@ mod test_quic {
             do_exporter_test(client_config, server_config);
         }
     }
+
+    #[test]
+    fn test_fragmented_append() {
+        // Create a QUIC client connection.
+        let client_config = make_client_config_with_versions(KeyType::Rsa, &[&rustls::version::TLS13]);
+        let client_config = Arc::new(client_config);
+        let mut client = quic::ClientConnection::new(
+            Arc::clone(&client_config),
+            quic::Version::V1,
+            server_name("localhost"),
+            b"client params"[..].into(),
+        )
+        .unwrap();
+
+        // Construct a message that is too large to fit in a single QUIC packet.
+        // We want the partial pieces to be large enough to overflow the deframer's
+        // 4096 byte buffer if mishandled.
+        let mut out = vec![0; 4096];
+        let len_bytes = u32::to_be_bytes(9266_u32);
+        out[1..4].copy_from_slice(&len_bytes[1..]);
+
+        // Read the message - this will put us into a joining handshake message state, buffering
+        // 4096 bytes into the deframer buffer.
+        client.read_hs(&out).unwrap();
+
+        // Read the message again - once more it isn't a complete message, so we'll try to
+        // append another 4096 bytes into the deframer buffer.
+        //
+        // If the deframer mishandles writing into the used buffer space this will panic with
+        // an index out of range error:
+        //   range end index 8192 out of range for slice of length 4096
+        client.read_hs(&out).unwrap();
+    }
 } // mod test_quic
 
 #[test]


### PR DESCRIPTION
_Draft opened on my fork for now because it seemed like an easier way to share progress/theories/notes but without a fix in hand it's noise on the main repo_

## Description

The `append_hs` function of the `MessageDeframer` (used only by QUIC connections) mishandles the case where we were in the process of deframing a QUIC HS message that required joining.

When copying a payload of the fragmented HS message into the deframer buffer the `DeframerBuffer<'a, ExternalPayload<'a>>` trait implementation for `DeframerVecBuffer` _already_ positioned the write into the unfilled section of the buffer, `self.unfilled()` (e.g. `self.buf[self.used..]`).

However, the branch of `append_hs` that continues processing of joining a fragmented HS message was incorrectly further offsetting the copy position by `meta.payload.end`, which is equal to `self.used` at this point. In effect trying to write to `self.buf[self.used+self.used..]`.

As a result, if we have buffered more than half the capacity of `self.buf` and then attempt to join in more payload bytes, the unfilled offset is outside the bounds of `buf` and an out-of-bounds indexing panic occurs.

## Testing

This was uncovered by @djc in the Quin Rustls 0.22 update (https://github.com/quinn-rs/quinn/pull/1715), with @Ralith [adding more context](https://github.com/quinn-rs/quinn/pull/1715#issuecomment-1909409691).

The Quinn [`server_can_send_3_inital_packets`](https://github.com/quinn-rs/quinn/blob/dcc8048974ce9b1ca6b365019149b5586ed88f4a/quinn-proto/src/tests/mod.rs#L1890-L1918) test happens to tickle this code path reliably in the client-side processing. In summary, the client reads 90 bytes of initial handshake data from the server - only complete messages are deframed. Subsequently the client reads a 1009 bytes that contains one complete message and the start of a longer message that will be fragmented over three subsequent `read_hs` calls - putting the deframer in a joining state. The first two messages are buffered in this joining state, using 3315 bytes of the deframer's 6258 byte buffer. Processing the third message panics when trying to write the last payload into `self.buf[3315+3315]`, an index of  6630, out of bounds for a 6258 byte buffer.

In this branch I reduced the bug to a smaller reproduction case, `test_quic::test_fragmented_append`.

Backporting this test to [Rustls 0.21](https://github.com/rustls/rustls/compare/rel-0.21...cpu:rustls:cpu-0.21-confirm-deframer-regression?expand=1) confirms this is likely a regression in 0.22.

<details>
<summary>Running the test w/ Rustls 0.21 with the `quic` feature enabled does not panic:</summary>

```
$ cargo test --package rustls --features quic --test api test_quic::test_fragmented_append -- --exact
    Finished test [unoptimized + debuginfo] target(s) in 0.04s
     Running tests/api.rs (target/debug/deps/api-a1de1914125ff8a7)

running 1 test
test test_quic::test_fragmented_append ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 132 filtered out; finished in 0.00s
```
</details>

Backporting the test to [Rustls 0.22](https://github.com/rustls/rustls/compare/rel-0.22...cpu:rustls:cpu-0.22-confirm-deframer-regression?expand=1).

<details>
<summary>As expected, it now panics:</summary>

```
$ cargo test --package rustls --test api test_quic::test_fragmented_append -- --exact
    Finished test [unoptimized + debuginfo] target(s) in 0.07s
     Running tests/api.rs (target/debug/deps/api-645d1b908f39f989)

running 1 test
test test_quic::test_fragmented_append ... FAILED

failures:

---- test_quic::test_fragmented_append stdout ----
thread 'test_quic::test_fragmented_append' panicked at rustls/src/msgs/deframer.rs:490:8:
range end index 8192 out of range for slice of length 4096
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    test_quic::test_fragmented_append

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 150 filtered out; finished in 0.00s

error: test failed, to rerun pass `-p rustls --test api`
```
</details>

And, to round out the testing, `main`:

<details>
<summary>The test panics:</summary>

```
cargo test --package rustls --test api test_with_aws_lc_rs::test_quic::test_fragmented_append -- --exact
    Finished test [unoptimized + debuginfo] target(s) in 0.07s
     Running tests/api.rs (target/debug/deps/api-29c926f07e602514)

running 1 test
test test_with_aws_lc_rs::test_quic::test_fragmented_append ... FAILED

failures:

---- test_with_aws_lc_rs::test_quic::test_fragmented_append stdout ----
thread 'test_with_aws_lc_rs::test_quic::test_fragmented_append' panicked at rustls/src/msgs/deframer.rs:497:24:
range end index 8192 out of range for slice of length 4096
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    test_with_aws_lc_rs::test_quic::test_fragmented_append

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 155 filtered out; finished in 0.00s

error: test failed, to rerun pass `-p rustls --test api`
```
</details>

## Fix

@Ralith [suggested](https://github.com/quinn-rs/quinn/pull/1715#issuecomment-1909409691) changing the `append_hs` call to `buffer.copy` to use `0` for the `at` argument instead of `meta.payload.end`. That does resolve the panic from the integration test, but breaks two other integration tests, suggesting this is insufficient:

* `test_with_aws_lc_rs::handshakes_complete_and_data_flows_with_gratuitious_max_fragment_sizes`
* `test_with_aws_lc_rs::test_server_mtu_reduction`

I haven't landed on a better fix yet, so this branch is opened as a draft to share partial work.
