### PR TITLE
ech: implement inner hello extension compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2273,6 +2273,7 @@ dependencies = [
  "async-std",
  "docopt",
  "env_logger",
+ "hickory-resolver",
  "log",
  "mio",
  "rcgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,17 +284,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-recursion"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
 name = "async-std"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,14 +854,14 @@ dependencies = [
 
 [[package]]
 name = "enum-as-inner"
-version = "0.6.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
+checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1150,15 +1139,15 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.5"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
- "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "http",
  "indexmap",
  "slab",
@@ -1199,60 +1188,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hickory-proto"
-version = "0.24.1"
-source = "git+https://github.com/hickory-dns/hickory-dns?rev=6334a01430088ead8642cafaee592ec7bf49831f#6334a01430088ead8642cafaee592ec7bf49831f"
-dependencies = [
- "async-recursion",
- "async-trait",
- "bytes",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "h2",
- "http",
- "idna",
- "ipnet",
- "once_cell",
- "rand",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
- "thiserror",
- "tinyvec",
- "tokio",
- "tokio-rustls",
- "tracing",
- "url",
- "webpki-roots 0.25.4",
-]
-
-[[package]]
-name = "hickory-resolver"
-version = "0.24.1"
-source = "git+https://github.com/hickory-dns/hickory-dns?rev=6334a01430088ead8642cafaee592ec7bf49831f#6334a01430088ead8642cafaee592ec7bf49831f"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-proto",
- "ipconfig",
- "lru-cache",
- "once_cell",
- "parking_lot",
- "rand",
- "resolv-conf",
- "rustls 0.21.12",
- "smallvec",
- "thiserror",
- "tokio",
- "tokio-rustls",
- "tracing",
- "webpki-roots 0.25.4",
-]
 
 [[package]]
 name = "hkdf"
@@ -1332,9 +1267,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.1.0"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -1346,6 +1281,17 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "idna"
@@ -1570,6 +1516,12 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
@@ -2048,7 +2000,7 @@ checksum = "54077e1872c46788540de1ea3d7f4ccb1983d12f9aa909b234468676c1a36779"
 dependencies = [
  "aws-lc-rs",
  "pem",
- "ring",
+ "ring 0.17.8",
  "rustls-pki-types",
  "time",
  "yasna",
@@ -2110,6 +2062,21 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -2198,14 +2165,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
 dependencies = [
  "log",
- "ring",
- "rustls-webpki 0.101.7",
+ "ring 0.16.20",
  "sct",
+ "webpki",
 ]
 
 [[package]]
@@ -2224,10 +2191,10 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "rcgen",
- "ring",
+ "ring 0.17.8",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
- "rustls-webpki 0.102.4",
+ "rustls-webpki",
  "rustversion",
  "serde",
  "serde_json",
@@ -2260,10 +2227,10 @@ dependencies = [
 name = "rustls-connect-tests"
 version = "0.0.1"
 dependencies = [
- "hickory-resolver",
  "regex",
- "ring",
+ "ring 0.17.8",
  "rustls 0.23.9",
+ "trust-dns-resolver",
 ]
 
 [[package]]
@@ -2273,7 +2240,6 @@ dependencies = [
  "async-std",
  "docopt",
  "env_logger",
- "hickory-resolver",
  "log",
  "mio",
  "rcgen",
@@ -2283,6 +2249,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "tokio",
+ "trust-dns-resolver",
  "webpki-roots 0.26.2",
 ]
 
@@ -2354,7 +2321,7 @@ dependencies = [
  "rsa",
  "rustls 0.23.9",
  "rustls-pki-types",
- "rustls-webpki 0.102.4",
+ "rustls-webpki",
  "sha2",
  "signature",
  "webpki-roots 0.26.2",
@@ -2374,22 +2341,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted 0.9.0",
-]
-
-[[package]]
-name = "rustls-webpki"
 version = "0.102.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
 dependencies = [
  "aws-lc-rs",
- "ring",
+ "ring 0.17.8",
  "rustls-pki-types",
  "untrusted 0.9.0",
 ]
@@ -2418,7 +2375,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring",
+ "ring 0.17.8",
  "untrusted 0.9.0",
 ]
 
@@ -2710,12 +2667,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls 0.21.12",
+ "rustls 0.20.9",
  "tokio",
+ "webpki",
 ]
 
 [[package]]
@@ -2760,6 +2718,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "trust-dns-proto"
+version = "0.22.0"
+source = "git+https://github.com/cpu/trust-dns?rev=9888378726ada266c1a6ac6b2630c2249f3f62cf#9888378726ada266c1a6ac6b2630c2249f3f62cf"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "h2",
+ "http",
+ "idna 0.2.3",
+ "ipnet",
+ "lazy_static",
+ "rand",
+ "rustls 0.20.9",
+ "rustls-pemfile 1.0.4",
+ "smallvec",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "url",
+ "webpki",
+ "webpki-roots 0.22.6",
+]
+
+[[package]]
+name = "trust-dns-resolver"
+version = "0.22.0"
+source = "git+https://github.com/cpu/trust-dns?rev=9888378726ada266c1a6ac6b2630c2249f3f62cf#9888378726ada266c1a6ac6b2630c2249f3f62cf"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "ipconfig",
+ "lazy_static",
+ "lru-cache",
+ "parking_lot",
+ "resolv-conf",
+ "rustls 0.20.9",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "trust-dns-proto",
+ "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -2818,7 +2830,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.5.0",
  "percent-encoding",
 ]
 
@@ -2935,10 +2947,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.25.4"
+name = "webpki"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
+dependencies = [
+ "ring 0.17.8",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
+]
 
 [[package]]
 name = "webpki-roots"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,6 +284,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "async-std"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1139,15 +1150,15 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "futures-util",
  "http",
  "indexmap",
  "slab",
@@ -1192,9 +1203,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hickory-proto"
 version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07698b8420e2f0d6447a436ba999ec85d8fbf2a398bbd737b82cac4a2e96e512"
+source = "git+https://github.com/hickory-dns/hickory-dns?rev=6334a01430088ead8642cafaee592ec7bf49831f#6334a01430088ead8642cafaee592ec7bf49831f"
 dependencies = [
+ "async-recursion",
  "async-trait",
  "bytes",
  "cfg-if",
@@ -1205,7 +1216,7 @@ dependencies = [
  "futures-util",
  "h2",
  "http",
- "idna 0.4.0",
+ "idna",
  "ipnet",
  "once_cell",
  "rand",
@@ -1223,8 +1234,7 @@ dependencies = [
 [[package]]
 name = "hickory-resolver"
 version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28757f23aa75c98f254cf0405e6d8c25b831b32921b050a66692427679b1f243"
+source = "git+https://github.com/hickory-dns/hickory-dns?rev=6334a01430088ead8642cafaee592ec7bf49831f#6334a01430088ead8642cafaee592ec7bf49831f"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1322,9 +1332,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
  "fnv",
@@ -1336,16 +1346,6 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "idna"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
 
 [[package]]
 name = "idna"
@@ -2817,7 +2817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
- "idna 0.5.0",
+ "idna",
  "percent-encoding",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,4 @@ lto = true
 [patch.crates-io]
 # TODO(XXX): Remove this once 0.25 is released - we want the ECH fixes from
 #            https://github.com/hickory-dns/hickory-dns/pull/2183
-hickory-resolver = { git = "https://github.com/hickory-dns/hickory-dns", rev = "6334a01430088ead8642cafaee592ec7bf49831f" }
+trust-dns-resolver = { git = "https://github.com/cpu/trust-dns", rev = "9888378726ada266c1a6ac6b2630c2249f3f62cf" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,8 @@ resolver = "2"
 [profile.bench]
 codegen-units = 1
 lto = true
+
+[patch.crates-io]
+# TODO(XXX): Remove this once 0.25 is released - we want the ECH fixes from
+#            https://github.com/hickory-dns/hickory-dns/pull/2183
+hickory-resolver = { git = "https://github.com/hickory-dns/hickory-dns", rev = "6334a01430088ead8642cafaee592ec7bf49831f" }

--- a/bogo/config.json.in
+++ b/bogo/config.json.in
@@ -28,7 +28,27 @@
     "ClientOCSPCallback*": "ocsp not supported yet",
     "ServerOCSPCallback*": "",
     "DuplicateCertCompressionExt*-TLS12": "RFC8879: if TLS 1.2 or earlier is negotiated, the peers MUST ignore this extension",
-    "TLS-ECH-*": "",
+#if defined(RING)
+    "TLS-ECH-*": "*ring* has no HPKE provider for ECH",
+#elif defined(AWS_LC_RS) && defined(FIPS)
+    "TLS-ECH-*": "ECH test suites use non-FIPS approved algos",
+#else
+    "TLS-ECH-Server*": "ECH server support NYI",
+    "TLS-ECH-Client-ExpectECHOuterExtensions": "ECH extension compression NYI",
+    "TLS-ECH-Client-CompressSupportedVersions": "ECH extension compression NYI",
+    "TLS-ECH-Client-SelectECHConfig": "TODO(XXX): re-enable after upstream bogo fix",
+    "TLS-ECH-Client-NoSupportedConfigs": "TODO(XXX): re-enable after upstream bogo fix",
+    "TLS-ECH-Client-SkipInvalidPublicName*": "we allow underscore names, don't fallback on no ECH configs",
+    "TLS-ECH-Client-NoSupportedConfigs-GREASE": "we don't fallback to GREASE for no ECH configs",
+    "TLS-ECH-Client-TLS12-RejectRetryConfigs": "we disable TLS1.2 w/ ECH",
+    "TLS-ECH-Client-Reject-NoClientCertificate-TLS12": "we disable TLS1.2 w/ ECH",
+    "TLS-ECH-Client-Reject-TLS12": "we disable TLS1.2 w/ ECH",
+    "TLS-ECH-Client-Reject-ResumeInnerSession-TLS12": "we disable TLS1.2 w/ ECH",
+    "TLS-ECH-GREASE-Client-TLS12-RejectRetryConfigs": "we disable TLS1.2 w/ ECH",
+    "TLS-ECH-Client-Reject-EarlyDataRejected-TLS12": "we disable TLS1.2 w/ ECH",
+    "TLS-ECH-Client-Reject-NoClientCertificate-TLS12-Async": "we disable TLS1.2 w/ ECH",
+    "TLS-ECH-Client-Reject-ResumeInnerSession-TLS13": "assumes no outter GREASE PSK, we send GREASE PSK",
+#endif
     "ALPS-*": "",
     "*Kyber*": "",
     "ExtraClientEncryptedExtension-*": "we don't implement ALPS",

--- a/bogo/config.json.in
+++ b/bogo/config.json.in
@@ -34,8 +34,6 @@
     "TLS-ECH-*": "ECH test suites use non-FIPS approved algos",
 #else
     "TLS-ECH-Server*": "ECH server support NYI",
-    "TLS-ECH-Client-ExpectECHOuterExtensions": "ECH extension compression NYI",
-    "TLS-ECH-Client-CompressSupportedVersions": "ECH extension compression NYI",
     "TLS-ECH-Client-SelectECHConfig": "TODO(XXX): re-enable after upstream bogo fix",
     "TLS-ECH-Client-NoSupportedConfigs": "TODO(XXX): re-enable after upstream bogo fix",
     "TLS-ECH-Client-SkipInvalidPublicName*": "we allow underscore names, don't fallback on no ECH configs",

--- a/bogo/runme
+++ b/bogo/runme
@@ -5,7 +5,7 @@
 
 set -xe
 
-case ${BOGO_SHIM_PROVIDER:-ring} in
+case ${BOGO_SHIM_PROVIDER:-aws-lc-rs} in
   ring)
       cargo build -p rustls --example bogo_shim $(../admin/all-features-except aws-lc-rs,aws_lc_rs,fips rustls)
       cpp -P -DRING config.json.in > config.json

--- a/connect-tests/Cargo.toml
+++ b/connect-tests/Cargo.toml
@@ -10,6 +10,6 @@ publish = false
 rustls = { path = "../rustls", features = [ "logging" ]}
 
 [dev-dependencies]
-hickory-resolver = { version = "0.24", features = ["dns-over-https-rustls", "webpki-roots"] }
+trust-dns-resolver = { version = "0.22", features = ["dns-over-https-rustls", "webpki-roots"] }
 regex = "1.0"
 ring = "0.17"

--- a/connect-tests/tests/ech.rs
+++ b/connect-tests/tests/ech.rs
@@ -1,11 +1,11 @@
 mod ech_config {
-    use hickory_resolver::config::{ResolverConfig, ResolverOpts};
-    use hickory_resolver::proto::rr::rdata::svcb::{SvcParamKey, SvcParamValue};
-    use hickory_resolver::proto::rr::{RData, RecordType};
-    use hickory_resolver::Resolver;
     use rustls::internal::msgs::codec::{Codec, Reader};
     use rustls::internal::msgs::handshake::EchConfig;
     use rustls::pki_types::EchConfigListBytes;
+    use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
+    use trust_dns_resolver::proto::rr::rdata::svcb::{SvcParamKey, SvcParamValue};
+    use trust_dns_resolver::proto::rr::{RData, RecordType};
+    use trust_dns_resolver::Resolver;
 
     #[test]
     fn cloudflare() {
@@ -24,8 +24,7 @@ mod ech_config {
 
     /// Lookup the ECH config list for a domain and deserialize it.
     fn test_deserialize_ech_config_list(domain: &str) {
-        let resolver =
-            Resolver::new(ResolverConfig::google_https(), ResolverOpts::default()).unwrap();
+        let resolver = Resolver::new(ResolverConfig::google(), ResolverOpts::default()).unwrap();
         let tls_encoded_list = lookup_ech(&resolver, domain);
         let parsed_configs = Vec::<EchConfig>::read(&mut Reader::init(&tls_encoded_list))
             .expect("failed to deserialize ECH config list");

--- a/connect-tests/tests/ech.rs
+++ b/connect-tests/tests/ech.rs
@@ -6,35 +6,39 @@ mod ech_config {
     use rustls::internal::msgs::codec::{Codec, Reader};
     use rustls::internal::msgs::enums::EchVersion;
     use rustls::internal::msgs::handshake::EchConfig;
+    use rustls::pki_types::EchConfigListBytes;
 
     #[test]
     fn cloudflare() {
-        test_deserialize_ech_config("crypto.cloudflare.com");
+        test_deserialize_ech_config_list("crypto.cloudflare.com");
     }
 
     #[test]
     fn defo_ie() {
-        test_deserialize_ech_config("defo.ie");
+        test_deserialize_ech_config_list("defo.ie");
     }
 
     #[test]
     fn tls_ech_dev() {
-        test_deserialize_ech_config("tls-ech.dev");
+        test_deserialize_ech_config_list("tls-ech.dev");
     }
 
-    /// Lookup the ECH config for a domain and deserialize it.
-    fn test_deserialize_ech_config(domain: &str) {
+    /// Lookup the ECH config list for a domain and deserialize it.
+    fn test_deserialize_ech_config_list(domain: &str) {
         let resolver =
             Resolver::new(ResolverConfig::google_https(), ResolverOpts::default()).unwrap();
-        let raw_value = lookup_ech(&resolver, domain);
-        let parsed_config = EchConfig::read(&mut Reader::init(&raw_value))
-            .expect("failed to deserialize ECH config");
-        assert_eq!(parsed_config.version, EchVersion::V14);
+        let tls_encoded_list = lookup_ech(&resolver, domain);
+        let parsed_configs = Vec::<EchConfig>::read(&mut Reader::init(&tls_encoded_list))
+            .expect("failed to deserialize ECH config list");
+        assert!(!parsed_configs.is_empty());
+        assert!(parsed_configs
+            .iter()
+            .all(|config| config.version == EchVersion::V14));
     }
 
     /// Use `resolver` to make an HTTPS record type query for `domain`, returning the
     /// first SvcParam EchConfig value found, panicing if none are returned.
-    fn lookup_ech(resolver: &Resolver, domain: &str) -> Vec<u8> {
+    fn lookup_ech(resolver: &Resolver, domain: &str) -> EchConfigListBytes<'static> {
         resolver
             .lookup(domain, RecordType::HTTPS)
             .expect("failed to lookup HTTPS record type")
@@ -44,11 +48,14 @@ mod ech_config {
                     .svc_params()
                     .iter()
                     .find_map(|sp| match sp {
-                        (SvcParamKey::EchConfig, SvcParamValue::EchConfig(e)) => Some(e.clone().0),
+                        (SvcParamKey::EchConfigList, SvcParamValue::EchConfigList(e)) => {
+                            Some(e.clone().0)
+                        }
                         _ => None,
                     }),
                 _ => None,
             })
             .expect("missing expected HTTPS SvcParam EchConfig record")
+            .into()
     }
 }

--- a/connect-tests/tests/ech.rs
+++ b/connect-tests/tests/ech.rs
@@ -4,7 +4,6 @@ mod ech_config {
     use hickory_resolver::proto::rr::{RData, RecordType};
     use hickory_resolver::Resolver;
     use rustls::internal::msgs::codec::{Codec, Reader};
-    use rustls::internal::msgs::enums::EchVersion;
     use rustls::internal::msgs::handshake::EchConfig;
     use rustls::pki_types::EchConfigListBytes;
 
@@ -33,7 +32,7 @@ mod ech_config {
         assert!(!parsed_configs.is_empty());
         assert!(parsed_configs
             .iter()
-            .all(|config| config.version == EchVersion::V14));
+            .all(|config| matches!(config, EchConfig::V18(_))));
     }
 
     /// Use `resolver` to make an HTTPS record type query for `domain`, returning the

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 async-std = { version = "1.12.0", features = ["attributes"], optional = true }
 docopt = "~1.1"
 env_logger = "0.10" # 0.11 requires 1.71 MSRV even as a dev-dep (due to manifest features)
-hickory-resolver = { version = "0.24", features = ["dns-over-https-rustls", "webpki-roots"] }
+trust-dns-resolver = { version = "0.22", features = ["dns-over-https-rustls", "webpki-roots"] }
 log = { version = "0.4.4" }
 mio = { version = "0.8", features = ["net", "os-poll"] }
 pki-types = { package = "rustls-pki-types", version = "1", features = ["std"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 async-std = { version = "1.12.0", features = ["attributes"], optional = true }
 docopt = "~1.1"
 env_logger = "0.10" # 0.11 requires 1.71 MSRV even as a dev-dep (due to manifest features)
+hickory-resolver = { version = "0.24", features = ["dns-over-https-rustls", "webpki-roots"] }
 log = { version = "0.4.4" }
 mio = { version = "0.8", features = ["net", "os-poll"] }
 pki-types = { package = "rustls-pki-types", version = "1", features = ["std"] }

--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -1,0 +1,102 @@
+//! This is a simple example demonstrating how to use Encrypted Client Hello (ECH) with
+//! rustls and hickory-dns.
+//!
+//! Note that `unwrap()` is used to deal with networking errors; this is not something
+//! that is sensible outside of example code.
+
+use std::io::{stdout, Read, Write};
+use std::net::TcpStream;
+use std::sync::Arc;
+
+use hickory_resolver::config::{ResolverConfig, ResolverOpts};
+use hickory_resolver::proto::rr::rdata::svcb::{SvcParamKey, SvcParamValue};
+use hickory_resolver::proto::rr::{RData, RecordType};
+use hickory_resolver::Resolver;
+use rustls::client::EchConfig;
+use rustls::crypto::aws_lc_rs;
+use rustls::crypto::aws_lc_rs::hpke::ALL_SUPPORTED_SUITES;
+use rustls::RootCertStore;
+
+fn main() {
+    // Find raw ECH configs using DNS-over-HTTPS with Hickory DNS:
+    let resolver = Resolver::new(ResolverConfig::google_https(), ResolverOpts::default()).unwrap();
+    let ech_config_list = lookup_ech_configs(&resolver, "defo.ie");
+
+    // NOTE: we defer setting up env_logger and setting the trace default filter level until
+    //       after doing the DNS-over-HTTPS lookup above - we don't want to muddy the output
+    //       with the rustls debug logs from the lookup.
+    env_logger::Builder::new()
+        .parse_filters("trace")
+        .init();
+
+    // Select a compatible ECH config.
+    let ech_config = EchConfig::new(ech_config_list, ALL_SUPPORTED_SUITES).unwrap();
+
+    let root_store = RootCertStore {
+        roots: webpki_roots::TLS_SERVER_ROOTS.into(),
+    };
+
+    // Construct a rustls client config with a custom provider, and ECH enabled.
+    let mut config =
+        rustls::ClientConfig::builder_with_provider(aws_lc_rs::default_provider().into())
+            .with_ech(ech_config)
+            .unwrap()
+            .with_root_certificates(root_store)
+            .with_no_client_auth();
+
+    // Allow using SSLKEYLOGFILE.
+    config.key_log = Arc::new(rustls::KeyLogFile::new());
+
+    // The "inner" SNI that we're really trying to reach.
+    let server_name = "www.defo.ie".try_into().unwrap();
+    let mut conn = rustls::ClientConnection::new(Arc::new(config), server_name).unwrap();
+    // The "outer" server that we're connecting to.
+    let mut sock = TcpStream::connect("defo.ie:443").unwrap();
+    let mut tls = rustls::Stream::new(&mut conn, &mut sock);
+    tls.write_all(
+        concat!(
+            "GET /ech-check.php HTTP/1.1\r\n",
+            "Host: defo.ie\r\n",
+            "Connection: close\r\n",
+            "Accept-Encoding: identity\r\n",
+            "\r\n"
+        )
+        .as_bytes(),
+    )
+    .unwrap();
+    let ciphersuite = tls
+        .conn
+        .negotiated_cipher_suite()
+        .unwrap();
+    writeln!(
+        &mut std::io::stderr(),
+        "Current ciphersuite: {:?}",
+        ciphersuite.suite()
+    )
+    .unwrap();
+    let mut plaintext = Vec::new();
+    tls.read_to_end(&mut plaintext).unwrap();
+    stdout().write_all(&plaintext).unwrap();
+}
+
+// TODO(@cpu): consider upstreaming to hickory-dns
+fn lookup_ech_configs(resolver: &Resolver, domain: &str) -> pki_types::EchConfigListBytes<'static> {
+    resolver
+        .lookup(domain, RecordType::HTTPS)
+        .expect("failed to lookup HTTPS record type")
+        .record_iter()
+        .find_map(|r| match r.data() {
+            Some(RData::HTTPS(svcb)) => svcb
+                .svc_params()
+                .iter()
+                .find_map(|sp| match sp {
+                    (SvcParamKey::EchConfigList, SvcParamValue::EchConfigList(e)) => {
+                        Some(e.clone().0)
+                    }
+                    _ => None,
+                }),
+            _ => None,
+        })
+        .expect("missing expected HTTPS SvcParam EchConfig record")
+        .into()
+}

--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -3,24 +3,63 @@
 //!
 //! Note that `unwrap()` is used to deal with networking errors; this is not something
 //! that is sensible outside of example code.
+//!
+//! Example usage:
+//! ```
+//! cargo run --package rustls-provider-example --example ech-client -- --host defo.ie defo.ie www.defo.ie
+//! ```
+//!
+//! This will perform a DNS-over-HTTPS lookup for the defo.ie ECH config, using it to determine
+//! the plaintext SNI to send to the server. The protected encrypted SNI will be "www.defo.ie".
+//! An HTTP request for Host: defo.ie will be made once the handshake completes. You should
+//! observe output that contains:
+//! ```
+//!   <p>SSL_ECH_OUTER_SNI: cover.defo.ie <br />
+//!   SSL_ECH_INNER_SNI: www.defo.ie <br />
+//!   SSL_ECH_STATUS: success <img src="greentick-small.png" alt="good" /> <br/>
+//!   </p>
+//! ```
 
-use std::io::{stdout, Read, Write};
-use std::net::TcpStream;
+use std::fs;
+use std::io::{stdout, BufReader, Read, Write};
+use std::net::{TcpStream, ToSocketAddrs};
 use std::sync::Arc;
 
+use docopt::Docopt;
 use hickory_resolver::config::{ResolverConfig, ResolverOpts};
 use hickory_resolver::proto::rr::rdata::svcb::{SvcParamKey, SvcParamValue};
 use hickory_resolver::proto::rr::{RData, RecordType};
 use hickory_resolver::Resolver;
-use rustls::client::EchConfig;
+use rustls::client::{EchConfig, EchGreaseConfig, EchStatus};
 use rustls::crypto::aws_lc_rs;
 use rustls::crypto::aws_lc_rs::hpke::ALL_SUPPORTED_SUITES;
+use rustls::crypto::hpke::Hpke;
+use rustls::pki_types::ServerName;
 use rustls::RootCertStore;
+use serde_derive::Deserialize;
 
 fn main() {
-    // Find raw ECH configs using DNS-over-HTTPS with Hickory DNS:
-    let resolver = Resolver::new(ResolverConfig::google_https(), ResolverOpts::default()).unwrap();
-    let ech_config_list = lookup_ech_configs(&resolver, "defo.ie");
+    let version = env!("CARGO_PKG_NAME").to_string() + ", version: " + env!("CARGO_PKG_VERSION");
+    let args: Args = Docopt::new(USAGE)
+        .map(|d| d.help(true))
+        .map(|d| d.version(Some(version)))
+        .and_then(|d| d.deserialize())
+        .unwrap_or_else(|e| e.exit());
+
+    // Find raw ECH configs using DNS-over-HTTPS with Hickory DNS.
+    let resolver_config = if args.flag_cloudflare_dns {
+        ResolverConfig::cloudflare_https()
+    } else {
+        ResolverConfig::google_https()
+    };
+    let resolver = Resolver::new(resolver_config, ResolverOpts::default()).unwrap();
+    let server_ech_config = match args.flag_grease {
+        true => None, // Force the use of the GREASE ext by skipping ECH config lookup
+        false => match args.flag_ech_config {
+            Some(path) => Some(read_ech(&path)),
+            None => lookup_ech_configs(&resolver, &args.arg_outer_hostname),
+        },
+    };
 
     // NOTE: we defer setting up env_logger and setting the trace default filter level until
     //       after doing the DNS-over-HTTPS lookup above - we don't want to muddy the output
@@ -29,13 +68,31 @@ fn main() {
         .parse_filters("trace")
         .init();
 
-    // Select a compatible ECH config.
-    let ech_mode = EchConfig::new(ech_config_list, ALL_SUPPORTED_SUITES)
-        .unwrap()
-        .into();
+    let ech_mode = match server_ech_config {
+        Some(ech_config_list) => EchConfig::new(ech_config_list, ALL_SUPPORTED_SUITES)
+            .unwrap()
+            .into(),
+        None => {
+            let (public_key, _) = GREASE_HPKE_SUITE
+                .generate_key_pair()
+                .unwrap();
+            EchGreaseConfig::new(GREASE_HPKE_SUITE, public_key).into()
+        }
+    };
 
-    let root_store = RootCertStore {
-        roots: webpki_roots::TLS_SERVER_ROOTS.into(),
+    let root_store = match args.flag_cafile {
+        Some(file) => {
+            let mut root_store = RootCertStore::empty();
+            let certfile = fs::File::open(file).expect("Cannot open CA file");
+            let mut reader = BufReader::new(certfile);
+            root_store.add_parsable_certificates(
+                rustls_pemfile::certs(&mut reader).map(|result| result.unwrap()),
+            );
+            root_store
+        }
+        None => RootCertStore {
+            roots: webpki_roots::TLS_SERVER_ROOTS.into(),
+        },
     };
 
     // Construct a rustls client config with a custom provider, and ECH enabled.
@@ -48,44 +105,106 @@ fn main() {
 
     // Allow using SSLKEYLOGFILE.
     config.key_log = Arc::new(rustls::KeyLogFile::new());
+    let config = Arc::new(config);
 
     // The "inner" SNI that we're really trying to reach.
-    let server_name = "www.defo.ie".try_into().unwrap();
-    let mut conn = rustls::ClientConnection::new(Arc::new(config), server_name).unwrap();
-    // The "outer" server that we're connecting to.
-    let mut sock = TcpStream::connect("defo.ie:443").unwrap();
-    let mut tls = rustls::Stream::new(&mut conn, &mut sock);
-    tls.write_all(
-        concat!(
-            "GET /ech-check.php HTTP/1.1\r\n",
-            "Host: defo.ie\r\n",
-            "Connection: close\r\n",
-            "Accept-Encoding: identity\r\n",
-            "\r\n"
-        )
-        .as_bytes(),
-    )
-    .unwrap();
-    let ciphersuite = tls
-        .conn
-        .negotiated_cipher_suite()
+    let server_name: ServerName<'static> = args
+        .arg_inner_hostname
+        .clone()
+        .try_into()
         .unwrap();
-    writeln!(
-        &mut std::io::stderr(),
-        "Current ciphersuite: {:?}",
-        ciphersuite.suite()
-    )
-    .unwrap();
-    let mut plaintext = Vec::new();
-    tls.read_to_end(&mut plaintext).unwrap();
-    stdout().write_all(&plaintext).unwrap();
+
+    for i in 0..args.flag_num_reqs {
+        println!("\nRequest {}", i);
+        let mut conn = rustls::ClientConnection::new(config.clone(), server_name.clone()).unwrap();
+        // The "outer" server that we're connecting to.
+        let sock_addr = (
+            args.arg_outer_hostname.as_str(),
+            args.flag_port.unwrap_or(443),
+        )
+            .to_socket_addrs()
+            .unwrap()
+            .next()
+            .unwrap();
+        let mut sock = TcpStream::connect(sock_addr).unwrap();
+        let mut tls = rustls::Stream::new(&mut conn, &mut sock);
+
+        let request =
+            format!(
+                "GET /{} HTTP/1.1\r\nHost: {}\r\nConnection: close\r\nAccept-Encoding: identity\r\n\r\n",
+                args.flag_path.clone()
+                    .unwrap_or("ech-check.php".to_owned()),
+                args.flag_host.as_ref().unwrap_or(&args.arg_inner_hostname),
+            );
+        dbg!(&request);
+        tls.write_all(request.as_bytes())
+            .unwrap();
+        assert!(!tls.conn.is_handshaking());
+        assert_eq!(
+            tls.conn.ech_status(),
+            match args.flag_grease {
+                true => EchStatus::Grease,
+                false => EchStatus::Accepted,
+            }
+        );
+        let mut plaintext = Vec::new();
+        tls.read_to_end(&mut plaintext).unwrap();
+        stdout().write_all(&plaintext).unwrap();
+    }
+}
+
+const USAGE: &str = "
+Connects to the TLS server at hostname:PORT.  The default PORT
+is 443. If an ECH config can be fetched for hostname using 
+DNS-over-HTTPS, ECH is enabled. Otherwise, a placeholder ECH
+extension is sent for anti-ossification testing.
+
+If --cafile is not supplied, a built-in set of CA certificates
+are used from the webpki-roots crate.
+
+Usage:
+  ech-client [options] <outer-hostname> <inner-hostname>
+  ech-client (--version | -v)
+  ech-client (--help | -h)
+
+Options:
+    -p, --port PORT       Connect to PORT [default: 443].
+    --cafile CAFILE       Read root certificates from CAFILE.
+    --path PATH           HTTP GET this PATH [default: ech-check.php].
+    --host HOST           HTTP HOST to use for GET request [default: inner-hostname].
+    --google-dns          Use Google DNS for the DNS-over-HTTPS lookup [default].
+    --cloudflare-dns      Use Cloudflare DNS for the DNS-over-HTTPS lookup.
+    --grease              Skip looking up an ECH config and send a GREASE placeholder.
+    --ech-config ECHFILE  Skip looking up an ECH config and read it from the provided file (in binary TLS encoding).
+    --num-reqs NUM        Number of requests to make [default: 1].
+    --version, -v         Show tool version.
+    --help, -h            Show this screen.
+";
+
+#[derive(Debug, Deserialize)]
+struct Args {
+    flag_port: Option<u16>,
+    flag_cafile: Option<String>,
+    flag_path: Option<String>,
+    flag_host: Option<String>,
+    #[allow(dead_code)] // implied default
+    flag_google_dns: bool,
+    flag_cloudflare_dns: bool,
+    flag_grease: bool,
+    flag_ech_config: Option<String>,
+    flag_num_reqs: usize,
+    arg_outer_hostname: String,
+    arg_inner_hostname: String,
 }
 
 // TODO(@cpu): consider upstreaming to hickory-dns
-fn lookup_ech_configs(resolver: &Resolver, domain: &str) -> pki_types::EchConfigListBytes<'static> {
+fn lookup_ech_configs(
+    resolver: &Resolver,
+    domain: &str,
+) -> Option<pki_types::EchConfigListBytes<'static>> {
     resolver
         .lookup(domain, RecordType::HTTPS)
-        .expect("failed to lookup HTTPS record type")
+        .ok()?
         .record_iter()
         .find_map(|r| match r.data() {
             Some(RData::HTTPS(svcb)) => svcb
@@ -99,6 +218,20 @@ fn lookup_ech_configs(resolver: &Resolver, domain: &str) -> pki_types::EchConfig
                 }),
             _ => None,
         })
-        .expect("missing expected HTTPS SvcParam EchConfig record")
-        .into()
+        .map(Into::into)
 }
+
+fn read_ech(path: &str) -> pki_types::EchConfigListBytes<'static> {
+    let file = fs::File::open(path).unwrap_or_else(|_| panic!("Cannot open ECH file: {path}"));
+    let mut reader = BufReader::new(file);
+    let mut bytes = Vec::new();
+    reader
+        .read_to_end(&mut bytes)
+        .unwrap_or_else(|_| panic!("Cannot read ECH file: {path}"));
+    bytes.into()
+}
+
+/// A HPKE suite to use for GREASE ECH.
+///
+/// A real implementation should vary this suite across all of the suites that are supported.
+static GREASE_HPKE_SUITE: &dyn Hpke = aws_lc_rs::hpke::DH_KEM_X25519_HKDF_SHA256_AES_128;

--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -26,10 +26,6 @@ use std::net::{TcpStream, ToSocketAddrs};
 use std::sync::Arc;
 
 use docopt::Docopt;
-use hickory_resolver::config::{ResolverConfig, ResolverOpts};
-use hickory_resolver::proto::rr::rdata::svcb::{SvcParamKey, SvcParamValue};
-use hickory_resolver::proto::rr::{RData, RecordType};
-use hickory_resolver::Resolver;
 use rustls::client::{EchConfig, EchGreaseConfig, EchStatus};
 use rustls::crypto::aws_lc_rs;
 use rustls::crypto::aws_lc_rs::hpke::ALL_SUPPORTED_SUITES;
@@ -37,6 +33,10 @@ use rustls::crypto::hpke::Hpke;
 use rustls::pki_types::ServerName;
 use rustls::RootCertStore;
 use serde_derive::Deserialize;
+use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
+use trust_dns_resolver::proto::rr::rdata::svcb::{SvcParamKey, SvcParamValue};
+use trust_dns_resolver::proto::rr::{RData, RecordType};
+use trust_dns_resolver::Resolver;
 
 fn main() {
     let version = env!("CARGO_PKG_NAME").to_string() + ", version: " + env!("CARGO_PKG_VERSION");
@@ -50,7 +50,7 @@ fn main() {
     let resolver_config = if args.flag_cloudflare_dns {
         ResolverConfig::cloudflare_https()
     } else {
-        ResolverConfig::google_https()
+        ResolverConfig::google()
     };
     let resolver = Resolver::new(resolver_config, ResolverOpts::default()).unwrap();
     let server_ech_config = match args.flag_grease {

--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -30,7 +30,9 @@ fn main() {
         .init();
 
     // Select a compatible ECH config.
-    let ech_config = EchConfig::new(ech_config_list, ALL_SUPPORTED_SUITES).unwrap();
+    let ech_mode = EchConfig::new(ech_config_list, ALL_SUPPORTED_SUITES)
+        .unwrap()
+        .into();
 
     let root_store = RootCertStore {
         roots: webpki_roots::TLS_SERVER_ROOTS.into(),
@@ -39,7 +41,7 @@ fn main() {
     // Construct a rustls client config with a custom provider, and ECH enabled.
     let mut config =
         rustls::ClientConfig::builder_with_provider(aws_lc_rs::default_provider().into())
-            .with_ech(ech_config)
+            .with_ech(ech_mode)
             .unwrap()
             .with_root_certificates(root_store)
             .with_no_client_auth();

--- a/rustls/examples/internal/bogo_shim_impl.rs
+++ b/rustls/examples/internal/bogo_shim_impl.rs
@@ -13,9 +13,7 @@ use base64::prelude::{Engine, BASE64_STANDARD};
 use pki_types::{CertificateDer, PrivateKeyDer, ServerName, UnixTime};
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::client::{ClientConfig, ClientConnection, Resumption, WebPkiServerVerifier};
-#[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
-use rustls::crypto::aws_lc_rs as provider;
-#[cfg(feature = "ring")]
+#[cfg(all(feature = "ring", not(feature = "aws_lc_rs")))]
 use rustls::crypto::ring as provider;
 use rustls::crypto::{CryptoProvider, SupportedKxGroup};
 use rustls::internal::msgs::codec::Codec;
@@ -27,6 +25,15 @@ use rustls::{
     CertificateError, Connection, DigitallySignedStruct, DistinguishedName, Error, HandshakeKind,
     InvalidMessage, NamedGroup, PeerIncompatible, PeerMisbehaved, ProtocolVersion, RootCertStore,
     Side, SignatureAlgorithm, SignatureScheme, SupportedProtocolVersion,
+};
+#[cfg(feature = "aws_lc_rs")]
+use rustls::{
+    client::{EchConfig, EchGreaseConfig, EchMode, EchStatus},
+    crypto::aws_lc_rs as provider,
+    crypto::aws_lc_rs::hpke,
+    crypto::hpke::{Hpke, HpkePublicKey},
+    internal::msgs::codec::Reader,
+    internal::msgs::handshake::EchConfig as EchConfigMsg,
 };
 
 static BOGO_NACK: i32 = 89;
@@ -88,6 +95,13 @@ struct Options {
     expect_handshake_kind_resumed: Option<Vec<HandshakeKind>>,
     install_cert_compression_algs: CompressionAlgs,
     provider: CryptoProvider,
+    ech_config_list: Option<pki_types::EchConfigListBytes<'static>>,
+    expect_ech_accept: bool,
+    expect_ech_retry_configs: Option<pki_types::EchConfigListBytes<'static>>,
+    on_resume_ech_config_list: Option<pki_types::EchConfigListBytes<'static>>,
+    on_resume_expect_ech_accept: bool,
+    on_initial_expect_ech_accept: bool,
+    enable_ech_grease: bool,
 }
 
 impl Options {
@@ -142,6 +156,13 @@ impl Options {
             expect_handshake_kind_resumed: Some(vec![HandshakeKind::Resumed]),
             install_cert_compression_algs: CompressionAlgs::None,
             provider: default_provider(),
+            ech_config_list: None,
+            expect_ech_accept: false,
+            expect_ech_retry_configs: None,
+            on_resume_ech_config_list: None,
+            on_resume_expect_ech_accept: false,
+            on_initial_expect_ech_accept: false,
+            enable_ech_grease: false,
         }
     }
 
@@ -690,11 +711,37 @@ fn make_client_cfg(opts: &Options) -> Arc<ClientConfig> {
             ..opts.provider.clone()
         }
         .into(),
-    )
-    .with_protocol_versions(&opts.supported_versions())
-    .expect("inconsistent settings")
-    .dangerous()
-    .with_custom_certificate_verifier(Arc::new(DummyServerAuth::new()));
+    );
+
+    #[cfg(feature = "aws_lc_rs")]
+    let cfg = if let Some(ech_config_list) = &opts.ech_config_list {
+        let ech_mode: EchMode = EchConfig::new(ech_config_list.clone(), hpke::ALL_SUPPORTED_SUITES)
+            .unwrap_or_else(|_| quit(":INVALID_ECH_CONFIG_LIST:"))
+            .into();
+
+        cfg.with_ech(ech_mode)
+            .expect("invalid ECH config")
+    } else if opts.enable_ech_grease {
+        let ech_mode = EchMode::Grease(EchGreaseConfig::new(
+            GREASE_HPKE_SUITE,
+            HpkePublicKey(GREASE_25519_PUBKEY.to_vec()),
+        ));
+
+        cfg.with_ech(ech_mode)
+            .expect("invalid GREASE ECH config")
+    } else {
+        cfg.with_protocol_versions(&opts.supported_versions())
+            .expect("inconsistent settings")
+    };
+
+    #[cfg(not(feature = "aws_lc_rs"))]
+    let cfg = cfg
+        .with_protocol_versions(&opts.supported_versions())
+        .expect("inconsistent settings");
+
+    let cfg = cfg
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(DummyServerAuth::new()));
 
     let mut cfg = if !opts.cert_file.is_empty() && !opts.key_file.is_empty() {
         let cert = load_cert(&opts.cert_file);
@@ -757,7 +804,7 @@ fn quit_err(why: &str) -> ! {
     process::exit(1)
 }
 
-fn handle_err(err: Error) -> ! {
+fn handle_err(opts: &Options, err: Error) -> ! {
     println!("TLS error: {:?}", err);
     thread::sleep(time::Duration::from_millis(100));
 
@@ -795,12 +842,31 @@ fn handle_err(err: Error) -> ! {
         | Error::InvalidMessage(InvalidMessage::InvalidEmptyPayload)
         | Error::InvalidMessage(InvalidMessage::UnknownProtocolVersion)
         | Error::InvalidMessage(InvalidMessage::MessageTooLarge) => quit(":GARBAGE:"),
+        Error::InvalidMessage(InvalidMessage::MessageTooShort)
+            if opts.enable_ech_grease || opts.ech_config_list.is_some() =>
+        {
+            quit(":ERROR_PARSING_EXTENSION:")
+        }
         Error::InvalidMessage(InvalidMessage::UnexpectedMessage(_)) => quit(":GARBAGE:"),
+        Error::DecryptError if opts.ech_config_list.is_some() => {
+            quit(":INCONSISTENT_ECH_NEGOTIATION:")
+        }
         Error::DecryptError => quit(":DECRYPTION_FAILED_OR_BAD_RECORD_MAC:"),
         Error::NoApplicationProtocol => quit(":NO_APPLICATION_PROTOCOL:"),
         Error::PeerIncompatible(
             PeerIncompatible::ServerSentHelloRetryRequestWithUnknownExtension,
         ) => quit(":UNEXPECTED_EXTENSION:"),
+        Error::PeerIncompatible(PeerIncompatible::ServerRejectedEncryptedClientHello(
+            _retry_configs,
+        )) => {
+            #[cfg(feature = "aws_lc_rs")]
+            if let Some(expected_configs) = &opts.expect_ech_retry_configs {
+                let expected_configs =
+                    Vec::<EchConfigMsg>::read(&mut Reader::init(expected_configs)).unwrap();
+                assert_eq!(_retry_configs, Some(expected_configs));
+            }
+            quit(":ECH_REJECTED:")
+        }
         Error::PeerIncompatible(_) => quit(":INCOMPATIBLE:"),
         Error::PeerMisbehaved(PeerMisbehaved::MissingPskModesExtension) => {
             quit(":MISSING_EXTENSION:")
@@ -832,6 +898,19 @@ fn handle_err(err: Error) -> ! {
         }
         Error::PeerMisbehaved(PeerMisbehaved::TooManyEmptyFragments) => {
             quit(":TOO_MANY_EMPTY_FRAGMENTS:")
+        }
+        Error::PeerMisbehaved(PeerMisbehaved::IllegalHelloRetryRequestWithInvalidEch)
+        | Error::PeerMisbehaved(PeerMisbehaved::UnsolicitedEchExtension) => {
+            quit(":UNEXPECTED_EXTENSION:")
+        }
+        // The TLS-ECH-Client-UnsolicitedInnerServerNameAck test is expected to fail with
+        // :UNEXPECTED_EXTENSION: when we receive an unsolicited inner hello SNI extension.
+        // We treat this the same as any unexpected enc'd ext and return :PEER_MISBEHAVIOUR:.
+        // Convert to the expected if this error occurs when we're configured w/ ECH.
+        Error::PeerMisbehaved(PeerMisbehaved::UnsolicitedEncryptedExtension)
+            if opts.ech_config_list.is_some() =>
+        {
+            quit(":UNEXPECTED_EXTENSION:")
         }
         Error::PeerMisbehaved(_) => quit(":PEER_MISBEHAVIOUR:"),
         Error::NoCertificatesPresented => quit(":NO_CERTS:"),
@@ -875,14 +954,14 @@ fn server(conn: &mut Connection) -> &mut ServerConnection {
 
 const MAX_MESSAGE_SIZE: usize = 0xffff + 5;
 
-fn after_read(sess: &mut Connection, conn: &mut net::TcpStream) {
+fn after_read(opts: &Options, sess: &mut Connection, conn: &mut net::TcpStream) {
     if let Err(err) = sess.process_new_packets() {
         flush(sess, conn); /* send any alerts before exiting */
-        handle_err(err);
+        handle_err(opts, err);
     }
 }
 
-fn read_n_bytes(sess: &mut Connection, conn: &mut net::TcpStream, n: usize) {
+fn read_n_bytes(opts: &Options, sess: &mut Connection, conn: &mut net::TcpStream, n: usize) {
     let mut bytes = [0u8; MAX_MESSAGE_SIZE];
     match conn.read(&mut bytes[..n]) {
         Ok(count) => {
@@ -894,17 +973,17 @@ fn read_n_bytes(sess: &mut Connection, conn: &mut net::TcpStream, n: usize) {
         Err(err) => panic!("invalid read: {}", err),
     };
 
-    after_read(sess, conn);
+    after_read(opts, sess, conn);
 }
 
-fn read_all_bytes(sess: &mut Connection, conn: &mut net::TcpStream) {
+fn read_all_bytes(opts: &Options, sess: &mut Connection, conn: &mut net::TcpStream) {
     match sess.read_tls(conn) {
         Ok(_) => {}
         Err(ref err) if err.kind() == io::ErrorKind::ConnectionReset => {}
         Err(err) => panic!("invalid read: {}", err),
     };
 
-    after_read(sess, conn);
+    after_read(opts, sess, conn);
 }
 
 fn exec(opts: &Options, mut sess: Connection, count: usize) {
@@ -930,7 +1009,7 @@ fn exec(opts: &Options, mut sess: Connection, count: usize) {
             {
                 flush(&mut sess, &mut conn);
                 for message_size_estimate in &opts.queue_early_data_after_received_messages {
-                    read_n_bytes(&mut sess, &mut conn, *message_size_estimate);
+                    read_n_bytes(opts, &mut sess, &mut conn, *message_size_estimate);
                 }
                 println!("now ready for early data");
             }
@@ -956,7 +1035,7 @@ fn exec(opts: &Options, mut sess: Connection, count: usize) {
         }
 
         if sess.wants_read() {
-            read_all_bytes(&mut sess, &mut conn);
+            read_all_bytes(opts, &mut sess, &mut conn);
         }
 
         if opts.side == Side::Server && opts.enable_early_data {
@@ -1044,6 +1123,18 @@ fn exec(opts: &Options, mut sess: Connection, count: usize) {
                 expected_options.contains(&actual),
                 "wanted to see {expected_options:?} but got {actual:?}"
             );
+        }
+
+        #[cfg(feature = "aws_lc_rs")]
+        {
+            let ech_accept_required =
+                (count == 0 && opts.on_initial_expect_ech_accept) || opts.expect_ech_accept;
+            if ech_accept_required
+                && !sess.is_handshaking()
+                && client(&mut sess).ech_status() != EchStatus::Accepted
+            {
+                quit_err("ECH was not accepted, but we expect the opposite");
+            }
         }
 
         let mut buf = [0u8; 1024];
@@ -1369,6 +1460,38 @@ pub fn main() {
                 println!("Not a FIPS build");
                 process::exit(BOGO_NACK);
             }
+            "-ech-config-list" => {
+                opts.ech_config_list = Some(BASE64_STANDARD.decode(args.remove(0).as_bytes())
+                    .expect("invalid ECH config base64").into());
+            }
+            "-expect-ech-accept" => {
+                opts.expect_ech_accept = true;
+            }
+            "-expect-ech-retry-configs" => {
+                opts.expect_ech_retry_configs = Some(BASE64_STANDARD.decode(args.remove(0).as_bytes())
+                    .expect("invalid ECH config base64").into());
+            }
+            "-on-resume-ech-config-list" => {
+                opts.on_resume_ech_config_list = Some(BASE64_STANDARD.decode(args.remove(0).as_bytes())
+                    .expect("invalid on resume ECH config base64").into());
+            }
+            "-on-resume-expect-ech-accept" => {
+                opts.on_resume_expect_ech_accept = true;
+            }
+            "-expect-no-ech-retry-configs" => {
+                opts.expect_ech_retry_configs = None;
+            }
+            "-on-initial-expect-ech-accept" => {
+                opts.on_initial_expect_ech_accept = true;
+            }
+            "-on-retry-expect-ech-retry-configs" => {
+                // Note: we treat this the same as -expect-ech-retry-configs
+                opts.expect_ech_retry_configs = Some(BASE64_STANDARD.decode(args.remove(0).as_bytes())
+                    .expect("invalid retry ECH config base64").into());
+            }
+            "-enable-ech-grease" => {
+                opts.enable_ech_grease = true;
+            }
 
             // defaults:
             "-enable-all-curves" |
@@ -1438,7 +1561,8 @@ pub fn main() {
             "-srtp-profiles" |
             "-permute-extensions" |
             "-signed-cert-timestamps" |
-            "-on-initial-expect-peer-cert-file" => {
+            "-on-initial-expect-peer-cert-file" |
+            "-use-custom-verify-callback" => {
                 println!("NYI option {:?}", arg);
                 process::exit(BOGO_NACK);
             }
@@ -1452,7 +1576,7 @@ pub fn main() {
 
     println!("opts {:?}", opts);
 
-    let (client_cfg, mut server_cfg) = match opts.side {
+    let (mut client_cfg, mut server_cfg) = match opts.side {
         Side::Client => (Some(make_client_cfg(&opts)), None),
         Side::Server => (None, Some(make_server_cfg(&opts))),
     };
@@ -1490,6 +1614,12 @@ pub fn main() {
         if opts.resume_with_tickets_disabled {
             opts.tickets = false;
             server_cfg = Some(make_server_cfg(&opts));
+        }
+        if opts.on_resume_ech_config_list.is_some() {
+            opts.ech_config_list
+                .clone_from(&opts.on_resume_ech_config_list);
+            opts.expect_ech_accept = opts.on_resume_expect_ech_accept;
+            client_cfg = Some(make_client_cfg(&opts));
         }
         opts.expect_handshake_kind
             .clone_from(&opts.expect_handshake_kind_resumed);
@@ -1630,3 +1760,12 @@ impl compress::CertCompressor for RandomAlgorithm {
         Ok(input)
     }
 }
+
+#[cfg(feature = "aws_lc_rs")]
+static GREASE_HPKE_SUITE: &dyn Hpke = hpke::DH_KEM_X25519_HKDF_SHA256_AES_128;
+
+#[cfg(feature = "aws_lc_rs")]
+const GREASE_25519_PUBKEY: &[u8] = &[
+    0x67, 0x35, 0xCA, 0x50, 0x21, 0xFC, 0x4F, 0xE6, 0x29, 0x3B, 0x31, 0x2C, 0xB5, 0xE0, 0x97, 0xD8,
+    0xD0, 0x58, 0x97, 0xCF, 0x5C, 0x15, 0x12, 0x79, 0x4B, 0xEF, 0x1D, 0x98, 0x52, 0x74, 0xDC, 0x5E,
+];

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -4,6 +4,7 @@ use alloc::vec::Vec;
 use core::fmt;
 use core::marker::PhantomData;
 
+use crate::client::EchConfig;
 use crate::crypto::CryptoProvider;
 use crate::error::Error;
 use crate::msgs::handshake::ALL_KEY_EXCHANGE_ALGORITHMS;
@@ -251,6 +252,7 @@ impl<S: ConfigSide> ConfigBuilder<S, WantsVersions> {
                 provider: self.state.provider,
                 versions: versions::EnabledVersions::new(versions),
                 time_provider: self.state.time_provider,
+                client_ech_config: None,
             },
             side: self.side,
         })
@@ -265,6 +267,7 @@ pub struct WantsVerifier {
     pub(crate) provider: Arc<CryptoProvider>,
     pub(crate) versions: versions::EnabledVersions,
     pub(crate) time_provider: Arc<dyn TimeProvider>,
+    pub(crate) client_ech_config: Option<EchConfig>,
 }
 
 /// Helper trait to abstract [`ConfigBuilder`] over building a [`ClientConfig`] or [`ServerConfig`].

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 use core::fmt;
 use core::marker::PhantomData;
 
-use crate::client::EchConfig;
+use crate::client::EchMode;
 use crate::crypto::CryptoProvider;
 use crate::error::Error;
 use crate::msgs::handshake::ALL_KEY_EXCHANGE_ALGORITHMS;
@@ -252,7 +252,7 @@ impl<S: ConfigSide> ConfigBuilder<S, WantsVersions> {
                 provider: self.state.provider,
                 versions: versions::EnabledVersions::new(versions),
                 time_provider: self.state.time_provider,
-                client_ech_config: None,
+                client_ech_mode: None,
             },
             side: self.side,
         })
@@ -267,7 +267,7 @@ pub struct WantsVerifier {
     pub(crate) provider: Arc<CryptoProvider>,
     pub(crate) versions: versions::EnabledVersions,
     pub(crate) time_provider: Arc<dyn TimeProvider>,
-    pub(crate) client_ech_config: Option<EchConfig>,
+    pub(crate) client_ech_mode: Option<EchMode>,
 }
 
 /// Helper trait to abstract [`ConfigBuilder`] over building a [`ClientConfig`] or [`ServerConfig`].

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -9,7 +9,7 @@ use pki_types::{ServerName, UnixTime};
 use super::handy::NoClientSessionStorage;
 use super::hs;
 use crate::builder::ConfigBuilder;
-use crate::client::{EchConfig, EchStatus};
+use crate::client::{EchMode, EchStatus};
 use crate::common_state::{CommonState, Protocol, Side};
 use crate::conn::{ConnectionCore, UnbufferedConnectionCommon};
 use crate::crypto::{CryptoProvider, SupportedKxGroup};
@@ -256,7 +256,7 @@ pub struct ClientConfig {
     pub cert_compression_cache: Arc<compress::CompressionCache>,
 
     /// How to offer Encrypted Client Hello (ECH). The default is to not offer ECH.
-    pub(super) ech_config: Option<EchConfig>,
+    pub(super) ech_mode: Option<EchMode>,
 }
 
 impl ClientConfig {

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -9,6 +9,7 @@ use pki_types::{ServerName, UnixTime};
 use super::handy::NoClientSessionStorage;
 use super::hs;
 use crate::builder::ConfigBuilder;
+use crate::client::EchConfig;
 use crate::common_state::{CommonState, Protocol, Side};
 use crate::conn::{ConnectionCore, UnbufferedConnectionCommon};
 use crate::crypto::{CryptoProvider, SupportedKxGroup};
@@ -134,6 +135,11 @@ pub trait ResolvesClientCert: fmt::Debug + Send + Sync {
 /// These must be created via the [`ClientConfig::builder()`] or [`ClientConfig::builder_with_provider()`]
 /// function.
 ///
+/// Note that using [`ClientConfig::with_ech]` will produce a common configuration specific to
+/// the provided [`crate::client::EchConfig`] that may not be appropriate for all connections made
+/// by the program. In this case the configuration should only be shared by connections intended
+/// for domains that offer the provided [`crate::client::EchConfig`] in their DNS zone.
+///
 /// # Defaults
 ///
 /// * [`ClientConfig::max_fragment_size`]: the default is `None` (meaning 16kB).
@@ -248,6 +254,9 @@ pub struct ClientConfig {
     /// This is optional: [`compress::CompressionCache::Disabled`] gives
     /// a cache that does no caching.
     pub cert_compression_cache: Arc<compress::CompressionCache>,
+
+    /// How to offer Encrypted Client Hello (ECH). The default is to not offer ECH.
+    pub(super) ech_config: Option<EchConfig>,
 }
 
 impl ClientConfig {

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -9,7 +9,7 @@ use pki_types::{ServerName, UnixTime};
 use super::handy::NoClientSessionStorage;
 use super::hs;
 use crate::builder::ConfigBuilder;
-use crate::client::EchConfig;
+use crate::client::{EchConfig, EchStatus};
 use crate::common_state::{CommonState, Protocol, Side};
 use crate::conn::{ConnectionCore, UnbufferedConnectionCommon};
 use crate::crypto::{CryptoProvider, SupportedKxGroup};
@@ -605,6 +605,7 @@ mod connection {
     use core::ops::{Deref, DerefMut};
     use std::io;
 
+    use crate::client::EchStatus;
     use pki_types::ServerName;
 
     use super::ClientConnectionData;
@@ -724,6 +725,11 @@ mod connection {
         /// Should be used with care as it exposes secret key material.
         pub fn dangerous_extract_secrets(self) -> Result<ExtractedSecrets, Error> {
             self.inner.dangerous_extract_secrets()
+        }
+
+        /// Return the connection's Encrypted Client Hello (ECH) status.
+        pub fn ech_status(&self) -> EchStatus {
+            self.inner.core.data.ech_status
         }
 
         fn write_early_data(&mut self, data: &[u8]) -> io::Result<usize> {
@@ -922,6 +928,7 @@ impl std::error::Error for EarlyDataError {}
 pub struct ClientConnectionData {
     pub(super) early_data: EarlyData,
     pub(super) resumption_ciphersuite: Option<SupportedCipherSuite>,
+    pub(super) ech_status: EchStatus,
 }
 
 impl ClientConnectionData {
@@ -929,6 +936,7 @@ impl ClientConnectionData {
         Self {
             early_data: EarlyData::new(),
             resumption_ciphersuite: None,
+            ech_status: EchStatus::NotOffered,
         }
     }
 }

--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -1,0 +1,105 @@
+use alloc::vec::Vec;
+
+use pki_types::EchConfigListBytes;
+
+use crate::crypto::hpke::{Hpke, HpkeSuite};
+#[cfg(feature = "logging")]
+use crate::log::{debug, warn};
+use crate::msgs::codec::{Codec, Reader};
+use crate::msgs::handshake::EchConfig as EchConfigMsg;
+use crate::{EncryptedClientHelloError, Error};
+
+/// Configuration for performing encrypted client hello.
+///
+/// Note: differs from the protocol-encoded EchConfig (`EchConfigMsg`).
+#[derive(Clone, Debug)]
+pub struct EchConfig {
+    /// The selected EchConfig.
+    pub(crate) config: EchConfigMsg,
+
+    /// An HPKE instance corresponding to a suite from the `config` we have selected as
+    /// a compatible choice.
+    pub(crate) suite: &'static dyn Hpke,
+}
+
+impl EchConfig {
+    /// Construct an EchConfig by selecting a ECH config from the provided bytes that is compatible
+    /// with one of the given HPKE suites.
+    ///
+    /// The config list bytes should be sourced from a DNS-over-HTTPS lookup resolving the `HTTPS`
+    /// resource record for the host name of the server you wish to connect via ECH,
+    /// and extracting the ECH configuration from the `ech` parameter. The extracted bytes should
+    /// be base64 decoded to yield the `EchConfigListBytes` you provide to rustls.
+    ///
+    /// One of the provided ECH configurations must be compatible with the HPKE provider's supported
+    /// suites or an error will be returned.
+    ///
+    /// See the [ech-client.rs] example for a complete example of fetching ECH configs from DNS.
+    ///
+    /// [ech-client.rs]: https://github.com/rustls/rustls/blob/main/provider-example/examples/ech-client.rs
+    pub fn new(
+        ech_config_list: EchConfigListBytes<'_>,
+        hpke_suites: &[&'static dyn Hpke],
+    ) -> Result<Self, Error> {
+        let ech_configs =
+            Vec::<EchConfigMsg>::read(&mut Reader::init(&ech_config_list)).map_err(|_| {
+                Error::InvalidEncryptedClientHello(EncryptedClientHelloError::InvalidConfigList)
+            })?;
+        let (config, suite) = Self::select_config_and_suite(ech_configs, hpke_suites)?;
+
+        Ok(Self { config, suite })
+    }
+
+    fn select_config_and_suite(
+        configs: Vec<EchConfigMsg>,
+        hpke_suites: &[&'static dyn Hpke],
+    ) -> Result<(EchConfigMsg, &'static dyn Hpke), Error> {
+        // Note: we name the index var _i because if the log feature is disabled
+        //       it is unused.
+        #[cfg_attr(not(feature = "std"), allow(clippy::unused_enumerate_index))]
+        for (_i, config) in configs.iter().enumerate() {
+            let contents = match config {
+                EchConfigMsg::V18(contents) => contents,
+                EchConfigMsg::Unknown {
+                    version: _version, ..
+                } => {
+                    warn!(
+                        "ECH config {} has unsupported version {:?}",
+                        _i + 1,
+                        _version
+                    );
+                    continue; // Unsupported version.
+                }
+            };
+
+            if contents.has_unknown_mandatory_extension() || contents.has_duplicate_extension() {
+                warn!("ECH config has duplicate, or unknown mandatory extensions: {contents:?}",);
+                continue; // Unsupported, or malformed extensions.
+            }
+
+            let key_config = &contents.key_config;
+            for cipher_suite in &key_config.symmetric_cipher_suites {
+                if cipher_suite.aead_id.tag_len().is_none() {
+                    continue; // Unsupported EXPORT_ONLY AEAD cipher suite.
+                }
+
+                let suite = HpkeSuite {
+                    kem: key_config.kem_id,
+                    sym: *cipher_suite,
+                };
+                if let Some(hpke) = hpke_suites
+                    .iter()
+                    .find(|hpke| hpke.suite() == suite)
+                {
+                    debug!(
+                        "selected ECH config ID {:?} suite {:?}",
+                        key_config.config_id, suite
+                    );
+                    return Ok((config.clone(), *hpke));
+                }
+            }
+        }
+
+        Err(EncryptedClientHelloError::NoCompatibleConfig.into())
+    }
+}

--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -47,6 +47,16 @@ pub enum EchMode {
     Grease(EchGreaseConfig),
 }
 
+impl EchMode {
+    /// Returns true if the ECH mode will use a FIPS approved HPKE suite.
+    pub fn fips(&self) -> bool {
+        match self {
+            Self::Enable(ech_config) => ech_config.suite.fips(),
+            Self::Grease(grease_config) => grease_config.suite.fips(),
+        }
+    }
+}
+
 impl From<EchConfig> for EchMode {
     fn from(config: EchConfig) -> Self {
         Self::Enable(config)

--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -14,12 +14,12 @@ use crate::hash_hs::{HandshakeHash, HandshakeHashBuffer};
 use crate::log::{debug, trace, warn};
 use crate::msgs::base::{Payload, PayloadU16};
 use crate::msgs::codec::{Codec, Reader};
-use crate::msgs::enums::ExtensionType;
+use crate::msgs::enums::{ExtensionType, HpkeKem};
 use crate::msgs::handshake::{
-    ClientExtension, ClientHelloPayload, EchConfig as EchConfigMsg, Encoding, EncryptedClientHello,
-    EncryptedClientHelloOuter, HandshakeMessagePayload, HandshakePayload, HelloRetryRequest,
-    HpkeSymmetricCipherSuite, PresharedKeyBinder, PresharedKeyOffer, Random, ServerHelloPayload,
-    SessionId,
+    ClientExtension, ClientHelloPayload, EchConfig as EchConfigMsg, EchConfigContents, Encoding,
+    EncryptedClientHello, EncryptedClientHelloOuter, HandshakeMessagePayload, HandshakePayload,
+    HelloRetryRequest, HpkeKeyConfig, HpkeSymmetricCipherSuite, PresharedKeyBinder,
+    PresharedKeyOffer, Random, ServerHelloPayload, SessionId,
 };
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;
@@ -32,6 +32,32 @@ use crate::{
     AlertDescription, CommonState, EncryptedClientHelloError, Error, HandshakeType,
     PeerIncompatible, PeerMisbehaved, ProtocolVersion, Tls13CipherSuite,
 };
+
+/// Controls how Encrypted Client Hello (ECH) is used in a client handshake.
+#[derive(Clone, Debug)]
+pub enum EchMode {
+    /// ECH is enabled and the ClientHello will be encrypted based on the provided
+    /// configuration.
+    Enable(EchConfig),
+
+    /// No ECH configuration is available but the client should act as though it were.
+    ///
+    /// This is an anti-ossification measure, sometimes referred to as "GREASE"[^0].
+    /// [^0]: <https://www.rfc-editor.org/rfc/rfc8701>
+    Grease(EchGreaseConfig),
+}
+
+impl From<EchConfig> for EchMode {
+    fn from(config: EchConfig) -> Self {
+        Self::Enable(config)
+    }
+}
+
+impl From<EchGreaseConfig> for EchMode {
+    fn from(config: EchGreaseConfig) -> Self {
+        Self::Grease(config)
+    }
+}
 
 /// Configuration for performing encrypted client hello.
 ///
@@ -139,11 +165,106 @@ impl EchConfig {
     }
 }
 
+/// Configuration for GREASE Encrypted Client Hello.
+#[derive(Clone, Debug)]
+pub struct EchGreaseConfig {
+    pub(crate) suite: &'static dyn Hpke,
+    pub(crate) placeholder_key: HpkePublicKey,
+}
+
+impl EchGreaseConfig {
+    /// Construct a GREASE ECH configuration.
+    ///
+    /// This configuration is used when the client wishes to offer ECH to prevent ossification,
+    /// but doesn't have a real ECH configuration to use for the remote server. In this case
+    /// a placeholder or "GREASE"[^0] extension is used.
+    ///
+    /// Returns an error if the HPKE provider does not support the given suite.
+    ///
+    /// [^0]: <https://www.rfc-editor.org/rfc/rfc8701>
+    pub fn new(suite: &'static dyn Hpke, placeholder_key: HpkePublicKey) -> Self {
+        Self {
+            suite,
+            placeholder_key,
+        }
+    }
+
+    /// Build a GREASE ECH extension based on the placeholder configuration.
+    ///
+    /// See <https://datatracker.ietf.org/doc/html/draft-ietf-tls-esni-18#name-grease-ech> for
+    /// more information.
+    pub(crate) fn grease_ext(
+        &self,
+        secure_random: &'static dyn SecureRandom,
+        inner_name: ServerName<'static>,
+        outer_hello: &ClientHelloPayload,
+    ) -> Result<ClientExtension, Error> {
+        trace!("Preparing GREASE ECH extension");
+
+        // Pick a random config id.
+        let mut config_id: [u8; 1] = [0; 1];
+        secure_random.fill(&mut config_id[..])?;
+
+        let suite = self.suite.suite();
+
+        // Construct a dummy ECH state - we don't have a real ECH config from a server since
+        // this is for GREASE.
+        let mut grease_state = EchState::new(
+            &EchConfig {
+                config: EchConfigMsg::V18(EchConfigContents {
+                    key_config: HpkeKeyConfig {
+                        config_id: config_id[0],
+                        kem_id: HpkeKem::DHKEM_P256_HKDF_SHA256,
+                        public_key: PayloadU16(self.placeholder_key.0.clone()),
+                        symmetric_cipher_suites: vec![suite.sym],
+                    },
+                    maximum_name_length: 0,
+                    public_name: DnsName::try_from("filler").unwrap(),
+                    extensions: Vec::default(),
+                }),
+                suite: self.suite,
+            },
+            inner_name,
+            false,
+            secure_random,
+            false, // Does not matter if we enable/disable SNI here. Inner hello is not used.
+        )?;
+
+        // Construct an inner hello using the outer hello - this allows us to know the size of
+        // dummy payload we should use for the GREASE extension.
+        let encoded_inner_hello = grease_state.encode_inner_hello(outer_hello, None, &None);
+
+        // Generate a payload of random data equivalent in length to a real inner hello.
+        let payload_len = encoded_inner_hello.len()
+            + suite
+                .sym
+                .aead_id
+                .tag_len()
+                // Safety: we have confirmed the AEAD is supported when building the config. All
+                //  supported AEADs have a tag length.
+                .unwrap();
+        let mut payload = vec![0; payload_len];
+        secure_random.fill(&mut payload)?;
+
+        // Return the GREASE extension.
+        Ok(ClientExtension::EncryptedClientHello(
+            EncryptedClientHello::Outer(EncryptedClientHelloOuter {
+                cipher_suite: suite.sym,
+                config_id: config_id[0],
+                enc: PayloadU16(grease_state.enc.0),
+                payload: PayloadU16::new(payload),
+            }),
+        ))
+    }
+}
+
 /// An enum representing ECH offer status.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum EchStatus {
     /// ECH was not offered - it is a normal TLS handshake.
     NotOffered,
+    /// GREASE ECH was sent. This is not considered offering ECH.
+    Grease,
     /// ECH was offered but we do not yet know whether the offer was accepted or rejected.
     Offered,
     /// ECH was offered and the server accepted.

--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -19,7 +19,7 @@ use crate::msgs::handshake::{
     ClientExtension, ClientHelloPayload, EchConfig as EchConfigMsg, EchConfigContents, Encoding,
     EncryptedClientHello, EncryptedClientHelloOuter, HandshakeMessagePayload, HandshakePayload,
     HelloRetryRequest, HpkeKeyConfig, HpkeSymmetricCipherSuite, PresharedKeyBinder,
-    PresharedKeyOffer, Random, ServerHelloPayload, SessionId,
+    PresharedKeyOffer, Random, ServerHelloPayload,
 };
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;
@@ -560,61 +560,109 @@ impl EchState {
         self.inner_hello_transcript = inner_transcript_buffer;
     }
 
+    // 5.1 "Encoding the ClientHelloInner"
     fn encode_inner_hello(
         &mut self,
         outer_hello: &ClientHelloPayload,
         retryreq: Option<&HelloRetryRequest>,
         resuming: &Option<Retrieved<&persist::Tls13ClientSessionValue>>,
     ) -> Vec<u8> {
-        // Start building an inner hello by cloning the initial outer hello.
-        let mut inner_hello = outer_hello.clone();
+        // Start building an inner hello using the outer_hello as a template.
+        let mut inner_hello = ClientHelloPayload {
+            // Some information is copied over as-is.
+            client_version: outer_hello.client_version,
+            session_id: outer_hello.session_id,
+            compression_methods: outer_hello.compression_methods.clone(),
 
-        inner_hello.extensions.retain(|ext| {
-            match ext.ext_type() {
-                // SNI is unconditionally removed - it was copied from the outer hello and
-                // we will conditionally re-add our own SNI for the inner hello later.
-                ExtensionType::ServerName |
-                // We may have copied extensions that are only useful in the context where a TLS 1.3
-                // connection allows TLS 1.2. This isn't the case for ECH and so we must remove these
-                // to satisfy a bogo test.
-                ExtensionType::ExtendedMasterSecret |
-                ExtensionType::SessionTicket |
-                ExtensionType::ECPointFormats => false,
-                // Retain all other extensions.
-                _ => true,
-            }
-        });
+            // We will build up the included extensions ourselves.
+            extensions: vec![],
 
-        // Remove the empty renegotiation info SCSV from the inner hello. Similar to the TLS 1.2
-        // specific extensions we remove above, this is seen as a TLS 1.2 only feature by bogo.
+            // Set the inner hello random to the one we generated when creating the ECH state.
+            // We hold on to the inner_hello_random in the ECH state to use later for confirming
+            // whether ECH was accepted or not.
+            random: self.inner_hello_random,
+
+            // We remove the empty renegotiation info SCSV from the outer hello's ciphersuite.
+            // Similar to the TLS 1.2 specific extensions we will filter out, this is seen as a
+            // TLS 1.2 only feature by bogo.
+            cipher_suites: outer_hello
+                .cipher_suites
+                .iter()
+                .filter(|cs| **cs != TLS_EMPTY_RENEGOTIATION_INFO_SCSV)
+                .cloned()
+                .collect(),
+        };
+
+        // The inner hello will always have an inner variant of the ECH extension added.
+        // See Section 6.1 rule 4.
         inner_hello
-            .cipher_suites
-            .retain(|cs| *cs != TLS_EMPTY_RENEGOTIATION_INFO_SCSV);
+            .extensions
+            .push(ClientExtension::EncryptedClientHello(
+                EncryptedClientHello::Inner,
+            ));
 
-        // Add the correct inner SNI - we only do this when the inner name is a DnsName and SNI
-        // is enabled. IP addresses should not be used in an SNI extensions.
-        if self.enable_sni {
-            if let ServerName::DnsName(inner_name) = &self.inner_name {
-                inner_hello
-                    .extensions
-                    .insert(0, ClientExtension::make_sni(&inner_name.borrow()));
+        let inner_sni = match &self.inner_name {
+            // The inner hello only gets a SNI value if enable_sni is true and the inner name
+            // is a domain name (not an IP address).
+            ServerName::DnsName(dns_name) if self.enable_sni => Some(dns_name),
+            _ => None,
+        };
+
+        // Now we consider each of the outer hello's extensions - we can either:
+        // 1. Omit the extension if it isn't appropriate (e.g. is a TLS 1.2 extension).
+        // 2. Add the extension to the inner hello as-is.
+        // 3. Compress the extension, by collecting it into a list of to-be-compressed
+        //    extensions we'll handle separately.
+        let mut compressed_exts = Vec::with_capacity(outer_hello.extensions.len());
+        let mut compressed_ext_types = Vec::with_capacity(outer_hello.extensions.len());
+        for ext in &outer_hello.extensions {
+            // Some outer hello extensions are only useful in the context where a TLS 1.3
+            // connection allows TLS 1.2. This isn't the case for ECH so we skip adding them
+            // to the inner hello.
+            if matches!(
+                ext.ext_type(),
+                ExtensionType::ExtendedMasterSecret
+                    | ExtensionType::SessionTicket
+                    | ExtensionType::ECPointFormats
+            ) {
+                continue;
+            }
+
+            if ext.ext_type() == ExtensionType::ServerName {
+                // We may want to replace the outer hello SNI with our own inner hello specific SNI.
+                if let Some(sni_value) = inner_sni {
+                    inner_hello
+                        .extensions
+                        .push(ClientExtension::make_sni(&sni_value.borrow()));
+                }
+                // We don't want to add, or compress, the SNI from the outer hello.
+                continue;
+            }
+
+            // Compressed extensions need to be put aside to include in one contiguous block.
+            // Uncompressed extensions get added directly to the inner hello.
+            if ext.ext_type().ech_compress() {
+                compressed_exts.push(ext.clone());
+                compressed_ext_types.push(ext.ext_type());
+            } else {
+                inner_hello.extensions.push(ext.clone());
             }
         }
 
-        // Add the inner variant extension to the inner hello.
-        // Section 6.1 rule 4.
-        let inner_ech_ext = ClientExtension::EncryptedClientHello(EncryptedClientHello::Inner);
-        if let Some(ClientExtension::PresharedKey(_)) = inner_hello.extensions.last() {
-            // Insert it before the PSK - this ext always needs to be last.
-            inner_hello
-                .extensions
-                .insert(inner_hello.extensions.len() - 1, inner_ech_ext);
-        } else {
-            // Insert it at the end. No PSK to worry about.
-            inner_hello
-                .extensions
-                .push(inner_ech_ext);
-        }
+        // We've added all the uncompressed extensions. Now we need to add the contiguous
+        // block of to-be-compressed extensions. Where we do this depends on whether the
+        // last uncompressed extension is a PSK for resumption. In this case we must
+        // add the to-be-compressed extensions _before_ the PSK.
+        let compressed_exts_index =
+            if let Some(ClientExtension::PresharedKey(_)) = inner_hello.extensions.last() {
+                inner_hello.extensions.len() - 1
+            } else {
+                inner_hello.extensions.len()
+            };
+        inner_hello.extensions.splice(
+            compressed_exts_index..compressed_exts_index,
+            compressed_exts,
+        );
 
         // Note which extensions we're sending in the inner hello. This may differ from
         // the outer hello (e.g. the inner hello may omit SNI while the outer hello will
@@ -624,11 +672,6 @@ impl EchState {
             .iter()
             .map(|ext| ext.ext_type())
             .collect();
-
-        // Set the inner hello random to the one we generated when creating the ECH state.
-        // We hold on to the inner_hello_random in the ECH state to use later for confirming
-        // whether ECH was accepted or not.
-        inner_hello.random = self.inner_hello_random;
 
         // If we're resuming, we need to update the PSK binder in the inner hello.
         if let Some(resuming) = resuming.as_ref() {
@@ -653,28 +696,12 @@ impl EchState {
             };
         }
 
-        // Repeating large extensions between ClientHelloInner and ClientHelloOuter can lead to excessive
-        // size. To reduce the size impact, the client MAY substitute extensions which it knows will be
-        // duplicated in ClientHelloOuter.
-
-        // TODO(@cpu): Extension compression would be handled here-ish.
-
-        // 5.1 "Encoding the ClientHelloInner"
-
-        // Setting the legacy_session_id field to the empty string.
-        // Preserve these for reuse
-        let original_session_id = inner_hello.session_id;
-
-        // SessionID is required to be empty in the EncodedClientHelloInner.
-        inner_hello.session_id = SessionId::empty();
-
-        // Encode the inner hello with the empty session ID.
-        let mut encoded_hello = inner_hello.get_encoding();
-
-        // Restore session ID.
-        inner_hello.session_id = original_session_id;
-
         trace!("ECH Inner Hello: {:#?}", inner_hello);
+
+        // Encode the inner hello according to the rules required for ECH. This differs
+        // from the standard encoding in several ways. Notably this is where we will
+        // replace the block of contiguous to-be-compressed extensions with a marker.
+        let mut encoded_hello = inner_hello.ech_inner_encoding(compressed_ext_types);
 
         // Calculate padding
         // max_name_len = L
@@ -700,7 +727,7 @@ impl EchState {
 
         // Let L be the length of the EncodedClientHelloInner with all the padding computed so far
         // Let N = 31 - ((L - 1) % 32) and add N bytes of padding.
-        let padding_len = 31 - ((encoded_hello.len() + (padding_len) - 1) % 32);
+        let padding_len = 31 - ((encoded_hello.len() + padding_len - 1) % 32);
         encoded_hello.extend(vec![0; padding_len]);
 
         // Construct the inner hello message that will be used for the transcript.

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -146,6 +146,17 @@ pub(super) fn start_handshake(
     let random = Random::new(config.provider.secure_random)?;
     let extension_order_seed = crate::rand::random_u16(config.provider.secure_random)?;
 
+    // TODO(XXX): Construct ECH context state, use to perform ECH flow when
+    //   emitting client hello.
+    let _ech_context = config
+        .ech_config
+        .as_ref()
+        .map(|ech_config| {
+            let _suite = &ech_config.suite;
+            let _config = &ech_config.config;
+            Some(())
+        });
+
     Ok(emit_client_hello_for_retry(
         transcript_buffer,
         None,

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -327,12 +327,6 @@ fn emit_client_hello_for_retry(
         }
     });
 
-    // Note what extensions we sent.
-    input.hello.sent_extensions = exts
-        .iter()
-        .map(ClientExtension::ext_type)
-        .collect();
-
     let mut cipher_suites: Vec<_> = config
         .provider
         .cipher_suites
@@ -345,16 +339,25 @@ fn emit_client_hello_for_retry(
     // We don't do renegotiation at all, in fact.
     cipher_suites.push(CipherSuite::TLS_EMPTY_RENEGOTIATION_INFO_SCSV);
 
+    let chp_payload = ClientHelloPayload {
+        client_version: ProtocolVersion::TLSv1_2,
+        random: input.random,
+        session_id: input.session_id,
+        cipher_suites,
+        compression_methods: vec![Compression::Null],
+        extensions: exts,
+    };
+
+    // Note what extensions we sent.
+    input.hello.sent_extensions = chp_payload
+        .extensions
+        .iter()
+        .map(ClientExtension::ext_type)
+        .collect();
+
     let mut chp = HandshakeMessagePayload {
         typ: HandshakeType::ClientHello,
-        payload: HandshakePayload::ClientHello(ClientHelloPayload {
-            client_version: ProtocolVersion::TLSv1_2,
-            random: input.random,
-            session_id: input.session_id,
-            cipher_suites,
-            compression_methods: vec![Compression::Null],
-            extensions: exts,
-        }),
+        payload: HandshakePayload::ClientHello(chp_payload),
     };
 
     let early_key_schedule = if let Some(resuming) = tls13_session {

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -16,7 +16,7 @@ use crate::check::inappropriate_handshake_message;
 use crate::client::client_conn::ClientConnectionData;
 use crate::client::common::ClientHelloDetails;
 use crate::client::ech::EchState;
-use crate::client::{tls13, ClientConfig, EchStatus};
+use crate::client::{tls13, ClientConfig, EchMode, EchStatus};
 use crate::common_state::{CommonState, HandshakeKind, State};
 use crate::conn::ConnectionRandoms;
 use crate::crypto::{ActiveKeyExchange, KeyExchangeAlgorithm};
@@ -147,8 +147,8 @@ pub(super) fn start_handshake(
     let random = Random::new(config.provider.secure_random)?;
     let extension_order_seed = crate::rand::random_u16(config.provider.secure_random)?;
 
-    let ech_state = match config.ech_config.as_ref() {
-        Some(ech_config) => Some(EchState::new(
+    let ech_state = match config.ech_mode.as_ref() {
+        Some(EchMode::Enable(ech_config)) => Some(EchState::new(
             ech_config,
             server_name.clone(),
             config
@@ -157,7 +157,7 @@ pub(super) fn start_handshake(
             config.provider.secure_random,
             config.enable_sni,
         )?),
-        None => None,
+        _ => None,
     };
 
     emit_client_hello_for_retry(
@@ -334,9 +334,9 @@ fn emit_client_hello_for_retry(
     exts.extend(extra_exts.iter().cloned());
 
     // If this is a second client hello we're constructing in response to an HRR, and
-    // we've rejected ECH, then we need to carry forward the exact same ECH
-    // extension we used in the first hello.
-    if matches!(cx.data.ech_status, EchStatus::Rejected) & retryreq.is_some() {
+    // we've rejected ECH or sent GREASE ECH, then we need to carry forward the
+    // exact same ECH extension we used in the first hello.
+    if matches!(cx.data.ech_status, EchStatus::Rejected | EchStatus::Grease) & retryreq.is_some() {
         if let Some(prev_ech_ext) = input.prev_ech_ext.take() {
             exts.push(prev_ech_ext);
         }
@@ -387,7 +387,6 @@ fn emit_client_hello_for_retry(
         extensions: exts,
     };
 
-    #[allow(clippy::single_match)] // TODO(@cpu): using a match to reduce churn.
     match (cx.data.ech_status, &mut ech_state) {
         // If we haven't offered ECH, or have offered ECH but got a non-rejecting HRR, then
         // we need to replace the client hello payload with an ECH client hello payload.
@@ -397,6 +396,25 @@ fn emit_client_hello_for_retry(
             cx.data.ech_status = EchStatus::Offered;
             // Store the ECH extension in case we need to carry it forward in a subsequent hello.
             input.prev_ech_ext = chp_payload.extensions.last().cloned();
+        }
+        // If we haven't offered ECH, and have no ECH state, then consider whether to use GREASE
+        // ECH.
+        (EchStatus::NotOffered, None) => {
+            if let Some(EchMode::Grease(grease_config)) = &config.ech_mode {
+                // Add the GREASE ECH extension.
+                let grease_ext = grease_config.grease_ext(
+                    config.provider.secure_random,
+                    input.server_name.clone(),
+                    &chp_payload,
+                )?;
+                chp_payload
+                    .extensions
+                    .push(grease_ext.clone());
+                cx.data.ech_status = EchStatus::Grease;
+                // Store the GREASE ECH extension in case we need to carry it forward in a
+                // subsequent hello.
+                input.prev_ech_ext = Some(grease_ext);
+            }
         }
         _ => {}
     }

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -10,6 +10,7 @@ use super::client_conn::ClientConnectionData;
 use super::hs::ClientContext;
 use crate::check::inappropriate_handshake_message;
 use crate::client::common::{ClientAuthDetails, ClientHelloDetails, ServerCertDetails};
+use crate::client::ech::EchState;
 use crate::client::{hs, ClientConfig, ClientSessionStore};
 use crate::common_state::{CommonState, HandshakeKind, Protocol, Side, State};
 use crate::conn::ConnectionRandoms;
@@ -72,6 +73,8 @@ pub(super) fn handle_server_hello(
     hello: ClientHelloDetails,
     our_key_share: Box<dyn ActiveKeyExchange>,
     mut sent_tls13_fake_ccs: bool,
+    ech_state: Option<EchState>,
+    server_hello_msg: &Message,
 ) -> hs::NextStateOrError<'static> {
     validate_server_hello(cx.common, server_hello)?;
 
@@ -145,6 +148,10 @@ pub(super) fn handle_server_hello(
     };
 
     let shared_secret = our_key_share.complete(&their_key_share.payload.0)?;
+
+    // TODO(@cpu): Handle confirmation of ECH.
+    let _ = ech_state;
+    let _ = server_hello_msg;
 
     let key_schedule = key_schedule_pre_handshake.into_handshake(shared_secret);
 

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -10,7 +10,7 @@ use super::client_conn::ClientConnectionData;
 use super::hs::ClientContext;
 use crate::check::inappropriate_handshake_message;
 use crate::client::common::{ClientAuthDetails, ClientHelloDetails, ServerCertDetails};
-use crate::client::ech::EchState;
+use crate::client::ech::{self, EchState, EchStatus};
 use crate::client::{hs, ClientConfig, ClientSessionStore};
 use crate::common_state::{CommonState, HandshakeKind, Protocol, Side, State};
 use crate::conn::ConnectionRandoms;
@@ -27,7 +27,7 @@ use crate::msgs::ccs::ChangeCipherSpecPayload;
 use crate::msgs::codec::{Codec, Reader};
 use crate::msgs::enums::{ExtensionType, KeyUpdateRequest};
 use crate::msgs::handshake::{
-    CertificatePayloadTls13, ClientExtension, HandshakeMessagePayload, HandshakePayload,
+    CertificatePayloadTls13, ClientExtension, EchConfig, HandshakeMessagePayload, HandshakePayload,
     HasServerExtensions, NewSessionTicketPayloadTls13, PresharedKeyIdentity, PresharedKeyOffer,
     ServerExtension, ServerHelloPayload, CERTIFICATE_MAX_SIZE_LIMIT,
 };
@@ -66,11 +66,11 @@ pub(super) fn handle_server_hello(
     server_hello: &ServerHelloPayload,
     mut resuming_session: Option<persist::Tls13ClientSessionValue>,
     server_name: ServerName<'static>,
-    randoms: ConnectionRandoms,
+    mut randoms: ConnectionRandoms,
     suite: &'static Tls13CipherSuite,
-    transcript: HandshakeHash,
+    mut transcript: HandshakeHash,
     early_key_schedule: Option<KeyScheduleEarly>,
-    hello: ClientHelloDetails,
+    mut hello: ClientHelloDetails,
     our_key_share: Box<dyn ActiveKeyExchange>,
     mut sent_tls13_fake_ccs: bool,
     ech_state: Option<EchState>,
@@ -149,11 +149,31 @@ pub(super) fn handle_server_hello(
 
     let shared_secret = our_key_share.complete(&their_key_share.payload.0)?;
 
-    // TODO(@cpu): Handle confirmation of ECH.
-    let _ = ech_state;
-    let _ = server_hello_msg;
+    let mut key_schedule = key_schedule_pre_handshake.into_handshake(shared_secret);
 
-    let key_schedule = key_schedule_pre_handshake.into_handshake(shared_secret);
+    // If we have ECH state, check that the server accepted our offer.
+    if let Some(ech_state) = ech_state {
+        cx.data.ech_status = match ech_state.confirm_acceptance(
+            &mut key_schedule,
+            server_hello,
+            suite.common.hash_provider,
+        )? {
+            // The server accepted our ECH offer, so complete the inner transcript with the
+            // server hello message, and switch the relevant state to the copies for the
+            // inner client hello.
+            Some(mut accepted) => {
+                accepted
+                    .transcript
+                    .add_message(server_hello_msg);
+                transcript = accepted.transcript;
+                randoms.client = accepted.random.0;
+                hello.sent_extensions = accepted.sent_extensions;
+                EchStatus::Accepted
+            }
+            // The server rejected our ECH offer.
+            None => EchStatus::Rejected,
+        };
+    }
 
     // Remember what KX group the server liked for next time.
     config
@@ -399,6 +419,22 @@ impl State<ClientConnectionData> for ExpectEncryptedExtensions {
         validate_encrypted_extensions(cx.common, &self.hello, exts)?;
         hs::process_alpn_protocol(cx.common, &self.config, exts.alpn_protocol())?;
 
+        let ech_retry_configs = match (cx.data.ech_status, exts.server_ech_extension()) {
+            // If we didn't offer ECH, or ECH was accepted, but the server sent an ECH encrypted
+            // extension with retry configs, we must error.
+            (EchStatus::NotOffered | EchStatus::Accepted, Some(_)) => {
+                return Err(cx.common.send_fatal_alert(
+                    AlertDescription::UnsupportedExtension,
+                    PeerMisbehaved::UnsolicitedEchExtension,
+                ))
+            }
+            // If we offered ECH, and it was rejected, store the retry configs (if any) from
+            // the server's ECH extension. We will return them in an error produced at the end
+            // of the handshake.
+            (EchStatus::Rejected, ext) => ext.map(|ext| ext.retry_configs.to_vec()),
+            _ => None,
+        };
+
         // QUIC transport parameters
         if cx.common.is_quic() {
             match exts.quic_params_extension() {
@@ -449,6 +485,7 @@ impl State<ClientConnectionData> for ExpectEncryptedExtensions {
                 client_auth: None,
                 cert_verified,
                 sig_verified,
+                ech_retry_configs,
             }))
         } else {
             if exts.early_data_extension_offered() {
@@ -466,6 +503,7 @@ impl State<ClientConnectionData> for ExpectEncryptedExtensions {
                     suite: self.suite,
                     transcript: self.transcript,
                     key_schedule: self.key_schedule,
+                    ech_retry_configs,
                 })
             } else {
                 Box::new(ExpectCertificateOrCertReq {
@@ -475,6 +513,7 @@ impl State<ClientConnectionData> for ExpectEncryptedExtensions {
                     suite: self.suite,
                     transcript: self.transcript,
                     key_schedule: self.key_schedule,
+                    ech_retry_configs,
                 })
             })
         }
@@ -492,6 +531,7 @@ struct ExpectCertificateOrCompressedCertificateOrCertReq {
     suite: &'static Tls13CipherSuite,
     transcript: HandshakeHash,
     key_schedule: KeyScheduleHandshake,
+    ech_retry_configs: Option<Vec<EchConfig>>,
 }
 
 impl State<ClientConnectionData> for ExpectCertificateOrCompressedCertificateOrCertReq {
@@ -520,6 +560,7 @@ impl State<ClientConnectionData> for ExpectCertificateOrCompressedCertificateOrC
                 key_schedule: self.key_schedule,
                 client_auth: None,
                 message_already_in_transcript: false,
+                ech_retry_configs: self.ech_retry_configs,
             })
             .handle(cx, m),
             MessagePayload::Handshake {
@@ -537,6 +578,7 @@ impl State<ClientConnectionData> for ExpectCertificateOrCompressedCertificateOrC
                 transcript: self.transcript,
                 key_schedule: self.key_schedule,
                 client_auth: None,
+                ech_retry_configs: self.ech_retry_configs,
             })
             .handle(cx, m),
             MessagePayload::Handshake {
@@ -554,6 +596,7 @@ impl State<ClientConnectionData> for ExpectCertificateOrCompressedCertificateOrC
                 transcript: self.transcript,
                 key_schedule: self.key_schedule,
                 offered_cert_compression: true,
+                ech_retry_configs: self.ech_retry_configs,
             })
             .handle(cx, m),
             payload => Err(inappropriate_handshake_message(
@@ -581,6 +624,7 @@ struct ExpectCertificateOrCompressedCertificate {
     transcript: HandshakeHash,
     key_schedule: KeyScheduleHandshake,
     client_auth: Option<ClientAuthDetails>,
+    ech_retry_configs: Option<Vec<EchConfig>>,
 }
 
 impl State<ClientConnectionData> for ExpectCertificateOrCompressedCertificate {
@@ -609,6 +653,7 @@ impl State<ClientConnectionData> for ExpectCertificateOrCompressedCertificate {
                 key_schedule: self.key_schedule,
                 client_auth: self.client_auth,
                 message_already_in_transcript: false,
+                ech_retry_configs: self.ech_retry_configs,
             })
             .handle(cx, m),
             MessagePayload::Handshake {
@@ -626,6 +671,7 @@ impl State<ClientConnectionData> for ExpectCertificateOrCompressedCertificate {
                 transcript: self.transcript,
                 key_schedule: self.key_schedule,
                 client_auth: self.client_auth,
+                ech_retry_configs: self.ech_retry_configs,
             })
             .handle(cx, m),
             payload => Err(inappropriate_handshake_message(
@@ -651,6 +697,7 @@ struct ExpectCertificateOrCertReq {
     suite: &'static Tls13CipherSuite,
     transcript: HandshakeHash,
     key_schedule: KeyScheduleHandshake,
+    ech_retry_configs: Option<Vec<EchConfig>>,
 }
 
 impl State<ClientConnectionData> for ExpectCertificateOrCertReq {
@@ -679,6 +726,7 @@ impl State<ClientConnectionData> for ExpectCertificateOrCertReq {
                 key_schedule: self.key_schedule,
                 client_auth: None,
                 message_already_in_transcript: false,
+                ech_retry_configs: self.ech_retry_configs,
             })
             .handle(cx, m),
             MessagePayload::Handshake {
@@ -696,6 +744,7 @@ impl State<ClientConnectionData> for ExpectCertificateOrCertReq {
                 transcript: self.transcript,
                 key_schedule: self.key_schedule,
                 offered_cert_compression: false,
+                ech_retry_configs: self.ech_retry_configs,
             })
             .handle(cx, m),
             payload => Err(inappropriate_handshake_message(
@@ -725,6 +774,7 @@ struct ExpectCertificateRequest {
     transcript: HandshakeHash,
     key_schedule: KeyScheduleHandshake,
     offered_cert_compression: bool,
+    ech_retry_configs: Option<Vec<EchConfig>>,
 }
 
 impl State<ClientConnectionData> for ExpectCertificateRequest {
@@ -801,6 +851,7 @@ impl State<ClientConnectionData> for ExpectCertificateRequest {
                 transcript: self.transcript,
                 key_schedule: self.key_schedule,
                 client_auth: Some(client_auth),
+                ech_retry_configs: self.ech_retry_configs,
             })
         } else {
             Box::new(ExpectCertificate {
@@ -812,6 +863,7 @@ impl State<ClientConnectionData> for ExpectCertificateRequest {
                 key_schedule: self.key_schedule,
                 client_auth: Some(client_auth),
                 message_already_in_transcript: false,
+                ech_retry_configs: self.ech_retry_configs,
             })
         })
     }
@@ -829,6 +881,7 @@ struct ExpectCompressedCertificate {
     transcript: HandshakeHash,
     key_schedule: KeyScheduleHandshake,
     client_auth: Option<ClientAuthDetails>,
+    ech_retry_configs: Option<Vec<EchConfig>>,
 }
 
 impl State<ClientConnectionData> for ExpectCompressedCertificate {
@@ -916,6 +969,7 @@ impl State<ClientConnectionData> for ExpectCompressedCertificate {
             key_schedule: self.key_schedule,
             client_auth: self.client_auth,
             message_already_in_transcript: true,
+            ech_retry_configs: self.ech_retry_configs,
         })
         .handle(cx, m)
     }
@@ -934,6 +988,7 @@ struct ExpectCertificate {
     key_schedule: KeyScheduleHandshake,
     client_auth: Option<ClientAuthDetails>,
     message_already_in_transcript: bool,
+    ech_retry_configs: Option<Vec<EchConfig>>,
 }
 
 impl State<ClientConnectionData> for ExpectCertificate {
@@ -987,6 +1042,7 @@ impl State<ClientConnectionData> for ExpectCertificate {
             key_schedule: self.key_schedule,
             server_cert,
             client_auth: self.client_auth,
+            ech_retry_configs: self.ech_retry_configs,
         }))
     }
 
@@ -1005,6 +1061,7 @@ struct ExpectCertificateVerify<'a> {
     key_schedule: KeyScheduleHandshake,
     server_cert: ServerCertDetails<'a>,
     client_auth: Option<ClientAuthDetails>,
+    ech_retry_configs: Option<Vec<EchConfig>>,
 }
 
 impl State<ClientConnectionData> for ExpectCertificateVerify<'_> {
@@ -1076,6 +1133,7 @@ impl State<ClientConnectionData> for ExpectCertificateVerify<'_> {
             client_auth: self.client_auth,
             cert_verified,
             sig_verified,
+            ech_retry_configs: self.ech_retry_configs,
         }))
     }
 
@@ -1089,6 +1147,7 @@ impl State<ClientConnectionData> for ExpectCertificateVerify<'_> {
             key_schedule: self.key_schedule,
             server_cert: self.server_cert.into_owned(),
             client_auth: self.client_auth,
+            ech_retry_configs: self.ech_retry_configs,
         })
     }
 }
@@ -1216,6 +1275,7 @@ struct ExpectFinished {
     client_auth: Option<ClientAuthDetails>,
     cert_verified: verify::ServerCertVerified,
     sig_verified: verify::HandshakeSignatureValid,
+    ech_retry_configs: Option<Vec<EchConfig>>,
 }
 
 impl State<ClientConnectionData> for ExpectFinished {
@@ -1269,6 +1329,14 @@ impl State<ClientConnectionData> for ExpectFinished {
                     emit_certificate_tls13(&mut st.transcript, None, auth_context, cx.common);
                 }
                 ClientAuthDetails::Verify {
+                    auth_context_tls13: auth_context,
+                    ..
+                } if cx.data.ech_status == EchStatus::Rejected => {
+                    // If ECH was offered, and rejected, we MUST respond with
+                    // an empty certificate message.
+                    emit_certificate_tls13(&mut st.transcript, None, auth_context, cx.common);
+                }
+                ClientAuthDetails::Verify {
                     certkey,
                     signer,
                     auth_context_tls13: auth_context,
@@ -1319,6 +1387,13 @@ impl State<ClientConnectionData> for ExpectFinished {
         let key_schedule_traffic = key_schedule_pre_finished.into_traffic(cx.common);
         cx.common
             .start_traffic(&mut cx.sendable_plaintext);
+
+        // Now that we've reached the end of the normal handshake we must enforce ECH acceptance by
+        // sending an alert and returning an error (potentially with retry configs) if the server
+        // did not accept our ECH offer.
+        if cx.data.ech_status == EchStatus::Rejected {
+            return Err(ech::fatal_alert_required(st.ech_retry_configs, cx.common));
+        }
 
         let st = ExpectTraffic {
             config: Arc::clone(&st.config),

--- a/rustls/src/crypto/hpke.rs
+++ b/rustls/src/crypto/hpke.rs
@@ -72,6 +72,12 @@ pub trait Hpke: Debug + Send + Sync {
         secret_key: &HpkePrivateKey,
     ) -> Result<Box<dyn HpkeOpener + 'static>, Error>;
 
+    /// Generate a new public key and private key pair compatible with this HPKE instance.
+    ///
+    /// Key pairs should be encoded as raw big endian fixed length integers sized based
+    /// on the suite's DH KEM algorithm.
+    fn generate_key_pair(&self) -> Result<(HpkePublicKey, HpkePrivateKey), Error>;
+
     /// Return whether the HPKE instance is FIPS compatible.
     fn fips(&self) -> bool {
         false

--- a/rustls/src/enums.rs
+++ b/rustls/src/enums.rs
@@ -42,6 +42,7 @@ enum_builder! {
         UnknownPSKIdentity => 0x73,
         CertificateRequired => 0x74,
         NoApplicationProtocol => 0x78,
+        EncryptedClientHelloRequired => 0x79, // https://datatracker.ietf.org/doc/html/draft-ietf-tls-esni-18#section-11.2
     }
 }
 
@@ -579,6 +580,19 @@ enum_builder! {
         Zlib => 1,
         Brotli => 2,
         Zstd => 3,
+    }
+}
+
+enum_builder! {
+    /// The type of Encrypted Client Hello (`EchClientHelloType`).
+    ///
+    /// Specified in [draft-ietf-tls-esni Section 5].
+    ///
+    /// [draft-ietf-tls-esni Section 5]: <https://www.ietf.org/archive/id/draft-ietf-tls-esni-18.html#section-5>
+    @U8
+    pub enum EchClientHelloType {
+        ClientHelloOuter => 0,
+        ClientHelloInner => 1
     }
 }
 

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -35,6 +35,9 @@ pub enum Error {
         got_type: HandshakeType,
     },
 
+    /// An error occurred while handling Encrypted Client Hello (ECH).
+    InvalidEncryptedClientHello(EncryptedClientHelloError),
+
     /// The peer sent us a TLS message with invalid contents.
     InvalidMessage(InvalidMessage),
 
@@ -480,6 +483,23 @@ impl From<CertRevocationListError> for Error {
     }
 }
 
+#[non_exhaustive]
+#[derive(Debug, Clone, Eq, PartialEq)]
+/// An error that occurred while handling Encrypted Client Hello (ECH).
+pub enum EncryptedClientHelloError {
+    /// The provided ECH configuration list was invalid.
+    InvalidConfigList,
+    /// No compatible ECH configuration.
+    NoCompatibleConfig,
+}
+
+impl From<EncryptedClientHelloError> for Error {
+    #[inline]
+    fn from(e: EncryptedClientHelloError) -> Self {
+        Self::InvalidEncryptedClientHello(e)
+    }
+}
+
 fn join<T: fmt::Debug>(items: &[T]) -> String {
     items
         .iter()
@@ -524,6 +544,9 @@ impl fmt::Display for Error {
             Self::NoCertificatesPresented => write!(f, "peer sent no certificates"),
             Self::UnsupportedNameType => write!(f, "presented server name type wasn't supported"),
             Self::DecryptError => write!(f, "cannot decrypt peer's message"),
+            Self::InvalidEncryptedClientHello(ref err) => {
+                write!(f, "encrypted client hello failure: {:?}", err)
+            }
             Self::EncryptError => write!(f, "cannot encrypt message"),
             Self::PeerSentOversizedRecord => write!(f, "peer sent excess record size"),
             Self::HandshakeNotComplete => write!(f, "handshake not complete"),

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -247,6 +247,7 @@ pub enum PeerMisbehaved {
     UnsolicitedSctList,
     UnsolicitedServerHelloExtension,
     WrongGroupForKeyShare,
+    UnsolicitedEchExtension,
 }
 
 impl From<PeerMisbehaved> for Error {

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -195,6 +195,7 @@ pub enum PeerMisbehaved {
     IllegalHelloRetryRequestWithUnofferedNamedGroup,
     IllegalHelloRetryRequestWithUnsupportedVersion,
     IllegalHelloRetryRequestWithWrongSessionId,
+    IllegalHelloRetryRequestWithInvalidEch,
     IllegalMiddleboxChangeCipherSpec,
     IllegalTlsInnerPlaintext,
     IncorrectBinder,

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -6,7 +6,7 @@ use core::fmt;
 use std::time::SystemTimeError;
 
 use crate::enums::{AlertDescription, ContentType, HandshakeType};
-use crate::msgs::handshake::KeyExchangeAlgorithm;
+use crate::msgs::handshake::{EchConfig, KeyExchangeAlgorithm};
 use crate::rand;
 
 /// rustls reports protocol errors using this type.
@@ -284,6 +284,7 @@ pub enum PeerIncompatible {
     Tls12NotOfferedOrEnabled,
     Tls13RequiredForQuic,
     UncompressedEcPointsRequired,
+    ServerRejectedEncryptedClientHello(Option<Vec<EchConfig>>),
 }
 
 impl From<PeerIncompatible> for Error {
@@ -491,6 +492,8 @@ pub enum EncryptedClientHelloError {
     InvalidConfigList,
     /// No compatible ECH configuration.
     NoCompatibleConfig,
+    /// The client configuration has server name indication (SNI) disabled.
+    SniRequired,
 }
 
 impl From<EncryptedClientHelloError> for Error {

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -556,7 +556,7 @@ pub mod client {
     };
     #[cfg(feature = "std")]
     pub use client_conn::{ClientConnection, WriteEarlyData};
-    pub use ech::{EchConfig, EchStatus};
+    pub use ech::{EchConfig, EchGreaseConfig, EchMode, EchStatus};
     #[cfg(any(feature = "std", feature = "hashbrown"))]
     pub use handy::ClientSessionMemoryCache;
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -429,7 +429,7 @@ pub mod internal {
     /// Low-level TLS message parsing and encoding functions.
     pub mod msgs {
         pub mod base {
-            pub use crate::msgs::base::Payload;
+            pub use crate::msgs::base::{Payload, PayloadU16};
         }
         pub mod codec {
             pub use crate::msgs::codec::{Codec, Reader};

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -556,7 +556,7 @@ pub mod client {
     };
     #[cfg(feature = "std")]
     pub use client_conn::{ClientConnection, WriteEarlyData};
-    pub use ech::EchConfig;
+    pub use ech::{EchConfig, EchStatus};
     #[cfg(any(feature = "std", feature = "hashbrown"))]
     pub use handy::ClientSessionMemoryCache;
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -514,8 +514,8 @@ pub use crate::enums::{
     ProtocolVersion, SignatureAlgorithm, SignatureScheme,
 };
 pub use crate::error::{
-    CertRevocationListError, CertificateError, Error, InvalidMessage, OtherError, PeerIncompatible,
-    PeerMisbehaved,
+    CertRevocationListError, CertificateError, EncryptedClientHelloError, Error, InvalidMessage,
+    OtherError, PeerIncompatible, PeerMisbehaved,
 };
 pub use crate::key_log::{KeyLog, NoKeyLog};
 #[cfg(feature = "std")]
@@ -542,6 +542,7 @@ pub mod client {
     pub(super) mod builder;
     mod client_conn;
     mod common;
+    mod ech;
     pub(super) mod handy;
     mod hs;
     #[cfg(feature = "tls12")]
@@ -555,6 +556,7 @@ pub mod client {
     };
     #[cfg(feature = "std")]
     pub use client_conn::{ClientConnection, WriteEarlyData};
+    pub use ech::EchConfig;
     #[cfg(any(feature = "std", feature = "hashbrown"))]
     pub use handy::ClientSessionMemoryCache;
 

--- a/rustls/src/msgs/enums.rs
+++ b/rustls/src/msgs/enums.rs
@@ -324,6 +324,19 @@ enum_builder! {
     }
 }
 
+impl HpkeAead {
+    /// Returns the length of the tag for the AEAD algorithm, or none if the AEAD is EXPORT_ONLY.
+    pub(crate) fn tag_len(&self) -> Option<usize> {
+        match self {
+            // See RFC 9180 Section 7.3, column `Nt`, the length in bytes of the authentication tag
+            // for the algorithm.
+            // https://www.rfc-editor.org/rfc/rfc9180.html#section-7.3
+            Self::AES_128_GCM | Self::AES_256_GCM | Self::CHACHA20_POLY_1305 => Some(16),
+            _ => None,
+        }
+    }
+}
+
 impl Default for HpkeAead {
     // TODO(XXX): revisit the default configuration. This is just what Cloudflare ships right now.
     fn default() -> Self {
@@ -340,7 +353,7 @@ enum_builder! {
     /// [draft-ietf-tls-esni Section 4]: <https://www.ietf.org/archive/id/draft-ietf-tls-esni-17.html#section-4>
     @U16
     pub enum EchVersion {
-        V14 => 0xfe0d,
+        V18 => 0xfe0d,
     }
 }
 

--- a/rustls/src/msgs/enums.rs
+++ b/rustls/src/msgs/enums.rs
@@ -116,6 +116,7 @@ enum_builder! {
         ChannelId => 0x754f,
         RenegotiationInfo => 0xff01,
         TransportParametersDraft => 0xffa5,
+        EncryptedClientHello => 0xfe0d, // https://datatracker.ietf.org/doc/html/draft-ietf-tls-esni-18#section-11.1
     }
 }
 

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -560,6 +560,7 @@ pub enum ClientExtension {
     EarlyData,
     CertificateCompressionAlgorithms(Vec<CertificateCompressionAlgorithm>),
     EncryptedClientHello(EncryptedClientHello),
+    EncryptedClientHelloOuterExtensions(Vec<ExtensionType>),
     Unknown(UnknownExtension),
 }
 
@@ -584,6 +585,9 @@ impl ClientExtension {
             Self::EarlyData => ExtensionType::EarlyData,
             Self::CertificateCompressionAlgorithms(_) => ExtensionType::CompressCertificate,
             Self::EncryptedClientHello(_) => ExtensionType::EncryptedClientHello,
+            Self::EncryptedClientHelloOuterExtensions(_) => {
+                ExtensionType::EncryptedClientHelloOuterExtensions
+            }
             Self::Unknown(ref r) => r.typ,
         }
     }
@@ -615,6 +619,7 @@ impl Codec<'_> for ClientExtension {
             }
             Self::CertificateCompressionAlgorithms(ref r) => r.encode(nested.buf),
             Self::EncryptedClientHello(ref r) => r.encode(nested.buf),
+            Self::EncryptedClientHelloOuterExtensions(ref r) => r.encode(nested.buf),
             Self::Unknown(ref r) => r.encode(nested.buf),
         }
     }
@@ -657,6 +662,9 @@ impl Codec<'_> for ClientExtension {
             ExtensionType::EarlyData if !sub.any_left() => Self::EarlyData,
             ExtensionType::CompressCertificate => {
                 Self::CertificateCompressionAlgorithms(Vec::read(&mut sub)?)
+            }
+            ExtensionType::EncryptedClientHelloOuterExtensions => {
+                Self::EncryptedClientHelloOuterExtensions(Vec::read(&mut sub)?)
             }
             _ => Self::Unknown(UnknownExtension::read(typ, &mut sub)),
         };
@@ -823,15 +831,7 @@ pub struct ClientHelloPayload {
 
 impl Codec<'_> for ClientHelloPayload {
     fn encode(&self, bytes: &mut Vec<u8>) {
-        self.client_version.encode(bytes);
-        self.random.encode(bytes);
-        self.session_id.encode(bytes);
-        self.cipher_suites.encode(bytes);
-        self.compression_methods.encode(bytes);
-
-        if !self.extensions.is_empty() {
-            self.extensions.encode(bytes);
-        }
+        self.payload_encode(bytes, Encoding::Standard)
     }
 
     fn read(r: &mut Reader) -> Result<Self, InvalidMessage> {
@@ -868,7 +868,73 @@ impl TlsListElement for ClientExtension {
     const SIZE_LEN: ListLength = ListLength::U16;
 }
 
+impl TlsListElement for ExtensionType {
+    const SIZE_LEN: ListLength = ListLength::U8;
+}
+
 impl ClientHelloPayload {
+    pub(crate) fn ech_inner_encoding(&self, to_compress: Vec<ExtensionType>) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        self.payload_encode(&mut bytes, Encoding::EchInnerHello { to_compress });
+        bytes
+    }
+
+    pub(crate) fn payload_encode(&self, bytes: &mut Vec<u8>, purpose: Encoding) {
+        self.client_version.encode(bytes);
+        self.random.encode(bytes);
+
+        match purpose {
+            // SessionID is required to be empty in the encoded inner client hello.
+            Encoding::EchInnerHello { .. } => SessionId::empty().encode(bytes),
+            _ => self.session_id.encode(bytes),
+        }
+
+        self.cipher_suites.encode(bytes);
+        self.compression_methods.encode(bytes);
+
+        match purpose {
+            // Compressed extensions must be replaced in the encoded inner client hello.
+            Encoding::EchInnerHello { to_compress } if !to_compress.is_empty() => {
+                // Safety: not empty check in match guard.
+                let first_compressed_type = *to_compress.first().unwrap();
+
+                // Compressed extensions are in a contiguous range and must be replaced
+                // with a marker extension.
+                let compressed_start_idx = self
+                    .extensions
+                    .iter()
+                    .position(|ext| ext.ext_type() == first_compressed_type);
+                let compressed_end_idx =
+                    compressed_start_idx.map(|start| start + to_compress.len());
+                let marker_ext = ClientExtension::EncryptedClientHelloOuterExtensions(to_compress);
+
+                let exts = self
+                    .extensions
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(i, ext)| {
+                        if Some(i) == compressed_start_idx {
+                            Some(&marker_ext)
+                        } else if Some(i) > compressed_start_idx && Some(i) < compressed_end_idx {
+                            None
+                        } else {
+                            Some(ext)
+                        }
+                    });
+
+                let nested = LengthPrefixedBuffer::new(ListLength::U16, bytes);
+                for ext in exts {
+                    ext.encode(nested.buf);
+                }
+            }
+            _ => {
+                if !self.extensions.is_empty() {
+                    self.extensions.encode(bytes);
+                }
+            }
+        }
+    }
+
     /// Returns true if there is more than one extension of a given
     /// type.
     pub(crate) fn has_duplicate_extension(&self) -> bool {
@@ -1209,10 +1275,6 @@ impl HelloRetryRequest {
         Compression::Null.encode(bytes);
 
         match purpose {
-            // Standard encoding encodes extensions as they appear.
-            Encoding::Standard => {
-                self.extensions.encode(bytes);
-            }
             // For the purpose of ECH confirmation, the Encrypted Client Hello extension
             // must have its payload replaced by 8 zero bytes.
             //
@@ -1231,6 +1293,9 @@ impl HelloRetryRequest {
                         }
                     }
                 }
+            }
+            _ => {
+                self.extensions.encode(bytes);
             }
         }
     }
@@ -1326,8 +1391,6 @@ impl ServerHelloPayload {
         self.legacy_version.encode(bytes);
 
         match encoding {
-            // Standard encoding encodes the random value as is.
-            Encoding::Standard => self.random.encode(bytes),
             // When encoding a ServerHello for ECH confirmation, the random value
             // has the last 8 bytes zeroed out.
             Encoding::EchConfirmation => {
@@ -1336,6 +1399,7 @@ impl ServerHelloPayload {
                 bytes.extend_from_slice(&rand_vec.as_slice()[..24]);
                 bytes.extend_from_slice(&[0u8; 8]);
             }
+            _ => self.random.encode(bytes),
         }
 
         self.session_id.encode(bytes);
@@ -3005,6 +3069,8 @@ pub(crate) enum Encoding {
     Standard,
     /// Encoding for ECH confirmation.
     EchConfirmation,
+    /// Encoding for ECH inner client hello.
+    EchInnerHello { to_compress: Vec<ExtensionType> },
 }
 
 fn has_duplicates<I: IntoIterator<Item = E>, E: Into<T>, T: Eq + Ord>(iter: I) -> bool {

--- a/rustls/src/tls13/key_schedule.rs
+++ b/rustls/src/tls13/key_schedule.rs
@@ -24,6 +24,7 @@ enum SecretKind {
     ResumptionMasterSecret,
     DerivedSecret,
     ServerEchConfirmationSecret,
+    ServerEchHrrConfirmationSecret,
 }
 
 impl SecretKind {
@@ -41,6 +42,8 @@ impl SecretKind {
             DerivedSecret => b"derived",
             // https://datatracker.ietf.org/doc/html/draft-ietf-tls-esni-18#section-7.2
             ServerEchConfirmationSecret => b"ech accept confirmation",
+            // https://datatracker.ietf.org/doc/html/draft-ietf-tls-esni-18#section-7.2.1
+            ServerEchHrrConfirmationSecret => b"hrr ech accept confirmation",
         }
     }
 
@@ -800,6 +803,29 @@ fn hkdf_expand_label_slice(
     hkdf_expand_label_inner(expander, label, context, output.len(), |e, info| {
         e.expand_slice(info, output)
     })
+}
+
+pub(crate) fn server_ech_hrr_confirmation_secret(
+    hkdf_provider: &'static dyn Hkdf,
+    client_hello_inner_random: &[u8],
+    hs_hash: hash::Output,
+) -> [u8; 8] {
+    /*
+    Per ietf-tls-esni-17 section 7.2.1:
+    <https://datatracker.ietf.org/doc/html/draft-ietf-tls-esni-17#section-7.2.1>
+    hrr_accept_confirmation = HKDF-Expand-Label(
+      HKDF-Extract(0, ClientHelloInner1.random),
+      "hrr ech accept confirmation",
+      transcript_hrr_ech_conf,
+      8)
+     */
+    hkdf_expand_label(
+        hkdf_provider
+            .extract_from_secret(None, client_hello_inner_random)
+            .as_ref(),
+        SecretKind::ServerEchHrrConfirmationSecret.to_bytes(),
+        hs_hash.as_ref(),
+    )
 }
 
 pub(crate) fn derive_traffic_key(expander: &dyn HkdfExpander, aead_key_len: usize) -> AeadKey {

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -28,6 +28,16 @@ use rustls::internal::msgs::handshake::{
 };
 use rustls::internal::msgs::message::{Message, MessagePayload, PlainMessage};
 use rustls::server::{ClientHello, ParsedCertificate, ResolvesServerCert};
+#[cfg(feature = "aws_lc_rs")]
+use rustls::{
+    client::{EchConfig, EchGreaseConfig, EchMode},
+    crypto::aws_lc_rs::hpke::ALL_SUPPORTED_SUITES,
+    internal::msgs::base::PayloadU16,
+    internal::msgs::handshake::{
+        EchConfig as EchConfigMsg, EchConfigContents, HpkeKeyConfig, HpkeSymmetricCipherSuite,
+    },
+    pki_types::{DnsName, EchConfigListBytes},
+};
 use rustls::{
     sign, AlertDescription, CertificateError, CipherSuite, ClientConfig, ClientConnection,
     ConnectionCommon, ConnectionTrafficSecrets, ContentType, DistinguishedName, Error,
@@ -6349,6 +6359,58 @@ fn test_server_fips_service_indicator_includes_require_ems() {
     assert!(server_config.fips());
     server_config.require_ems = false;
     assert!(!server_config.fips());
+}
+
+#[cfg(feature = "aws_lc_rs")]
+#[test]
+fn test_client_fips_service_indicator_includes_ech_hpke_suite() {
+    if !provider_is_fips() {
+        return;
+    }
+
+    for suite in ALL_SUPPORTED_SUITES {
+        let (public_key, _) = suite.generate_key_pair().unwrap();
+
+        let suite_id = suite.suite();
+        let bogus_config = EchConfigMsg::V18(EchConfigContents {
+            key_config: HpkeKeyConfig {
+                config_id: 10,
+                kem_id: suite_id.kem,
+                public_key: PayloadU16(public_key.0.clone()),
+                symmetric_cipher_suites: vec![HpkeSymmetricCipherSuite {
+                    kdf_id: suite_id.sym.kdf_id,
+                    aead_id: suite_id.sym.aead_id,
+                }],
+            },
+            maximum_name_length: 0,
+            public_name: DnsName::try_from("example.com").unwrap(),
+            extensions: vec![],
+        });
+        let mut bogus_config_bytes = Vec::new();
+        vec![bogus_config].encode(&mut bogus_config_bytes);
+        let ech_config =
+            EchConfig::new(EchConfigListBytes::from(bogus_config_bytes), &[*suite]).unwrap();
+
+        // A ECH client configuration should only be considered FIPS approved if the
+        // ECH HPKE suite is itself FIPS approved.
+        let config = ClientConfig::builder_with_provider(provider::default_provider().into())
+            .with_ech(EchMode::Enable(ech_config))
+            .unwrap();
+        let config = finish_client_config(KeyType::Rsa2048, config);
+        assert_eq!(config.fips(), suite.fips());
+
+        // The same applies if an ECH GREASE client configuration is used.
+        let config = ClientConfig::builder_with_provider(provider::default_provider().into())
+            .with_ech(EchMode::Grease(EchGreaseConfig::new(*suite, public_key)))
+            .unwrap();
+        let config = finish_client_config(KeyType::Rsa2048, config);
+        assert_eq!(config.fips(), suite.fips());
+
+        // And a connection made from a client config should retain the fips status of the
+        // config w.r.t the HPKE suite.
+        let conn = ClientConnection::new(config.into(), ServerName::DnsName(DnsName::try_from("example.org").unwrap())).unwrap();
+        assert_eq!(conn.fips(), suite.fips());
+    }
 }
 
 #[test]

--- a/rustls/tests/ech.rs
+++ b/rustls/tests/ech.rs
@@ -2,18 +2,19 @@ use base64::prelude::{Engine, BASE64_STANDARD};
 use pki_types::DnsName;
 use rustls::internal::msgs::codec::{Codec, Reader};
 use rustls::internal::msgs::enums::{EchVersion, HpkeAead, HpkeKdf, HpkeKem};
-use rustls::internal::msgs::handshake::{EchConfig, HpkeKeyConfig, HpkeSymmetricCipherSuite};
+use rustls::internal::msgs::handshake::{
+    EchConfig, EchConfigContents, HpkeKeyConfig, HpkeSymmetricCipherSuite,
+};
 
 #[test]
 fn test_decode_config_list() {
-    fn assert_config(config: &EchConfig, public_name: impl AsRef<[u8]>, max_len: u8) {
-        assert_eq!(config.version, EchVersion::V14);
-        assert_eq!(config.contents.maximum_name_length, max_len);
+    fn assert_config(contents: &EchConfigContents, public_name: impl AsRef<[u8]>, max_len: u8) {
+        assert_eq!(contents.maximum_name_length, max_len);
         assert_eq!(
-            config.contents.public_name,
+            contents.public_name,
             DnsName::try_from(public_name.as_ref()).unwrap()
         );
-        assert!(config.contents.extensions.0.is_empty());
+        assert!(contents.extensions.is_empty());
     }
 
     fn assert_key_config(
@@ -29,9 +30,12 @@ fn test_decode_config_list() {
 
     let config_list = get_ech_config(BASE64_ECHCONFIG_LIST_LOCALHOST);
     assert_eq!(config_list.len(), 1);
-    assert_config(&config_list[0], "localhost", 128);
+    let EchConfig::V18(contents) = &config_list[0] else {
+        panic!("unexpected ECH config version: {:?}", config_list[0]);
+    };
+    assert_config(contents, "localhost", 128);
     assert_key_config(
-        &config_list[0].contents.key_config,
+        &contents.key_config,
         0,
         HpkeKem::DHKEM_X25519_HKDF_SHA256,
         vec![
@@ -48,9 +52,12 @@ fn test_decode_config_list() {
 
     let config_list = get_ech_config(BASE64_ECHCONFIG_LIST_CF);
     assert_eq!(config_list.len(), 2);
-    assert_config(&config_list[0], "cloudflare-esni.com", 37);
+    let EchConfig::V18(contents_a) = &config_list[0] else {
+        panic!("unexpected ECH config version: {:?}", config_list[0]);
+    };
+    assert_config(contents_a, "cloudflare-esni.com", 37);
     assert_key_config(
-        &config_list[0].contents.key_config,
+        &contents_a.key_config,
         195,
         HpkeKem::DHKEM_X25519_HKDF_SHA256,
         vec![HpkeSymmetricCipherSuite {
@@ -58,9 +65,12 @@ fn test_decode_config_list() {
             aead_id: HpkeAead::AES_128_GCM,
         }],
     );
-    assert_config(&config_list[1], "cloudflare-esni.com", 42);
+    let EchConfig::V18(contents_b) = &config_list[1] else {
+        panic!("unexpected ECH config version: {:?}", config_list[1]);
+    };
+    assert_config(contents_b, "cloudflare-esni.com", 42);
     assert_key_config(
-        &config_list[1].contents.key_config,
+        &contents_b.key_config,
         3,
         HpkeKem::DHKEM_P256_HKDF_SHA256,
         vec![HpkeSymmetricCipherSuite {
@@ -68,6 +78,21 @@ fn test_decode_config_list() {
             aead_id: HpkeAead::AES_128_GCM,
         }],
     );
+
+    let config_list = get_ech_config(BASE64_ECHCONFIG_LIST_WITH_UNSUPPORTED);
+    assert_eq!(config_list.len(), 4);
+    // The first config should be unsupported.
+    assert!(matches!(
+        config_list[0],
+        EchConfig::Unknown {
+            version: EchVersion::Unknown(0xBADD),
+            ..
+        }
+    ));
+    // The other configs should be recognized.
+    for config in config_list.iter().skip(1) {
+        assert!(matches!(config, EchConfig::V18(_)));
+    }
 }
 
 #[test]
@@ -81,6 +106,7 @@ fn test_echconfig_serialization() {
 
     assert_round_trip_eq(BASE64_ECHCONFIG_LIST_LOCALHOST);
     assert_round_trip_eq(BASE64_ECHCONFIG_LIST_CF);
+    assert_round_trip_eq(BASE64_ECHCONFIG_LIST_WITH_UNSUPPORTED);
 }
 
 fn get_ech_config(s: &str) -> Vec<EchConfig> {
@@ -95,3 +121,6 @@ const BASE64_ECHCONFIG_LIST_LOCALHOST: &str =
 // Two EchConfigs, both with server-name "cloudflare-esni.com".
 const BASE64_ECHCONFIG_LIST_CF: &str =
     "AK3+DQBCwwAgACAJ9T5U4FeM6631r2bvAuGtmEd8zQaoTkFAtArTcMl/XQAEAAEAASUTY2xvdWRmbGFyZS1lc25pLmNvbQAA/g0AYwMAEABBBGGbUlGLuGRorUeFwmrgHImkrh9uxoPrnFKpS5bQvnc5grfMS3PvymQ2FYL02WQi1ZzZJg5OsYYdzlaGYnEoJNsABAABAAEqE2Nsb3VkZmxhcmUtZXNuaS5jb20AAA==";
+
+// Three EchConfigs, the first one with an unsupported version.
+const BASE64_ECHCONFIG_LIST_WITH_UNSUPPORTED: &str = "AQW63QAFBQQDAgH+DQBmAAAQAEEE5itp4r9ln5e+Lx4NlIpM1Zdrt6keDUb73ampHp3culoB59aXqAoY+cPEox5W4nyDSNsWGhz1HX7xlC1Lz3IiwQAMAAEAAQABAAIAAQADQA5wdWJsaWMuZXhhbXBsZQAA/g0APQAAIAAgfWYWFXMCFK7ucFMzZvNqYJ6tZcDCCOYjIjRqtbzY3hwABBERIiJADnB1YmxpYy5leGFtcGxlAAD+DQBNAAAgACCFvWoDJ3wlQntS4mngx3qOtSS6HrPS8TJmLUsKxstzVwAMAAEAAQABAAIAAQADQA5wdWJsaWMuZXhhbXBsZQAIqqoABHRlc3Q=";


### PR DESCRIPTION
**Note: opened as a draft pending https://github.com/rustls/rustls/pull/1718 being merged first**

This commit extends the existing client-side ECH support to enable the "SHOULD" recommendation of compressing extensions that are identical between the outer client hello and the inner client hello. This optimization reduces the overhead of ECH, shrinking the total client hello size.

Achieving this is a bit tricky (which is why it was done separately at the end!). To-be-compressed extensions must be in a contiguous block in the inner hello. When we encode that contiguous block for the encoded inner hello, we replace the block with a marker extension listing all of the extension types that were replaced. In the outer hello the compressed extensions must be present in the same relative order (but don't need to be contiguous).

With this feature implemented we can also activate a couple of bogo tests that were previously excluded.